### PR TITLE
feat: migrate localStorage state to DB-backed with stale-while-revalidate

### DIFF
--- a/docs/plans/2026-03-08-localstorage-to-db-design.md
+++ b/docs/plans/2026-03-08-localstorage-to-db-design.md
@@ -1,0 +1,216 @@
+# LocalStorage → Database Migration Design
+
+**Date:** 2026-03-08
+**Goal:** Multi-device sync — DB as single source of truth, localStorage as stale-while-revalidate cache only.
+**Approach:** DB-First with localStorage Cache (Approach A)
+
+---
+
+## 1. LocalStorage Audit Summary
+
+### 13 Keys Found Across 8 Files
+
+| # | Key | Category | Action |
+|---|-----|----------|--------|
+| 1 | `selectedMeals_${weekStart}` | DATA — dual-write problem | **MIGRATE** to DB-primary |
+| 2 | `inStoreCheckedItems` | DATA — no DB backing | **MIGRATE** to new DB table |
+| 3 | `chatSessionId_${weekStart}` | SESSION — random UUID | **MAKE DETERMINISTIC** |
+| 4 | `creatorSessionId_${weekStart}` | SESSION — random UUID | **MAKE DETERMINISTIC** |
+| 5 | `inStoreShoppingList` | CACHE — already DB-backed | **KEEP** as cache (no change) |
+| 6 | `theme` | UI preference | **KEEP** in localStorage |
+| 7 | `planTabState` | UI preference | **KEEP** in localStorage |
+| 8 | `recipeKitchenMode` | UI preference | **KEEP** in localStorage |
+| 9 | `recipeSwipeHintShown` | UI hint flag | **KEEP** in localStorage |
+| 10 | `recipeInstructionState` | Temp step progress | **KEEP** in localStorage |
+| 11 | `n8n_recipe_ingredients` | DEAD CODE | **REMOVE** |
+| 12 | `n8n_recipe_ingredients_raw` | DEAD CODE | **REMOVE** |
+
+---
+
+## 2. Database Changes
+
+### Existing Tables (no schema changes)
+
+**`weekly_selections`** — Already stores meal selections per week.
+```
+selection_id (PK AUTO_INCREMENT)
+WeekDateRange VARCHAR(255)     -- 'For the week of March 8th to March 14th, 2026'
+recipe_id INT                  -- FK to recipe_summary.recipe_id
+notes TEXT
+created_at TIMESTAMP
+```
+
+**`recipe_summary`** — Rich meal data (name, description, times, servings, difficulty, tags).
+
+**`WeeklyGroceryList`** — Grocery items with IsSelected, Quantity, WeekDateRange, DataSource.
+
+### New Table: `shopping_progress`
+
+Tracks which items a user has checked off during in-store shopping.
+
+```sql
+CREATE TABLE shopping_progress (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  week_start_date VARCHAR(20) NOT NULL,       -- '2026-03-08'
+  item_id INT NOT NULL,                        -- WeeklyGroceryList item ID
+  checked_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_week_item (week_start_date, item_id)
+);
+```
+
+**Design rationale:**
+- Row-per-checked-item: queryable, easy to add/remove individual items via INSERT/DELETE
+- `week_start_date` scopes to grocery week (matches existing week-keying pattern)
+- UNIQUE constraint prevents duplicate checks
+- Uncheck = DELETE row. Get progress = SELECT all rows for week.
+
+### Tables NOT Needed
+
+- No `user_preferences` table — theme/planTab/kitchenMode are UI preferences, fine in localStorage
+- No `user_sessions` table — session IDs become deterministic (computed, not stored)
+
+---
+
+## 3. Data Flow Changes
+
+### 3.1 selectedMeals — localStorage-primary → DB-primary
+
+**Current flow (BROKEN for multi-device):**
+```
+App mount → localStorage.getItem('selectedMeals_${week}') → React state → props
+Mutation → setSelectedMeals() → useEffect writes localStorage
+MealCreator also writes to DB (dual-write)
+ChatBot does NOT always write to DB (inconsistent)
+```
+
+**New flow:**
+```
+App mount → show cached localStorage instantly (stale-while-revalidate)
+         → GET /choose_recipe_instructions (existing endpoint)
+         → update React state + localStorage cache
+         → props to children (unchanged interface)
+
+Add meal    → POST /add_weekly_selection → DB insert → return updated list → setState
+Remove meal → POST /remove_weekly_selection → DB delete → return updated list → setState
+```
+
+**Key principle:** Mutations go through DB first. Local state refreshes from DB response. This guarantees DB and UI stay in sync.
+
+**selectedMeals object shape reconciliation:**
+
+Current localStorage shape:
+```json
+{ "id": 1741419600000, "name": "Turkey Tacos", "recipeId": "61", "ingredients": [] }
+```
+
+DB JOIN shape (from chooseRecipeInstructions):
+```json
+{
+  "selection_id": 70, "recipe_id": 61, "recipe_name": "Classic Turkey Taco Night...",
+  "recipe_description": "...", "prep_time_minutes": 10, "cook_time_minutes": 15,
+  "servings": 4, "difficulty_level": "easy", "tags": "..."
+}
+```
+
+**Mapping:** Components use `meal.name` and `meal.recipeId`. The DB response provides `recipe_name` and `recipe_id`. A thin mapping layer in App.js normalizes the DB response to match the existing prop interface:
+```js
+const normalizedMeals = dbResponse.map(row => ({
+  id: row.selection_id,
+  name: row.recipe_name,
+  recipeId: String(row.recipe_id),
+  // bonus fields from DB:
+  description: row.recipe_description,
+  prepTime: row.prep_time_minutes,
+  cookTime: row.cook_time_minutes,
+  servings: row.servings,
+  difficulty: row.difficulty_level,
+  tags: row.tags
+}));
+```
+
+### 3.2 Session IDs — Random → Deterministic
+
+**Current:** `session_2026-03-08_a1b2c3d4e` (random, stored in localStorage)
+**New:** `chat_2026-03-08` and `creator_2026-03-08` (deterministic, computed)
+
+**Migration strategy:**
+- On component mount, check localStorage for existing session ID for current week
+- If found → use it (backward compatible, preserves active conversation)
+- If not found → use deterministic format
+- New weeks always use deterministic format
+- Old week histories naturally expire (already inaccessible due to week-keying)
+
+### 3.3 inStoreCheckedItems — localStorage → DB
+
+**Current:** Read/write `inStoreCheckedItems` in localStorage only.
+
+**New n8n endpoints:**
+- `POST /shopping_progress/check` — body: `{ week_start_date, item_id }` → INSERT row
+- `POST /shopping_progress/uncheck` — body: `{ week_start_date, item_id }` → DELETE row
+- `GET /shopping_progress?week_start_date=2026-03-08` → return all checked item_ids for week
+
+**InStoreMode mount sequence:**
+1. Fetch checked items from `GET /shopping_progress?week_start_date=...`
+2. Fall back to localStorage if fetch fails (offline resilience)
+3. On toggle: write to DB, update local state, cache to localStorage
+
+### 3.4 inStoreShoppingList — No change
+
+Already has 3-tier resolution: prop → localStorage → API fetch. This is a good pattern. Keep as-is.
+
+---
+
+## 4. New n8n Webhooks Required
+
+| Endpoint | Method | Purpose | DB Operation |
+|----------|--------|---------|-------------|
+| `/add_weekly_selection` | POST | Add meal to week | INSERT into weekly_selections |
+| `/remove_weekly_selection` | POST | Remove meal from week | DELETE from weekly_selections |
+| `/shopping_progress_check` | POST | Mark item checked | INSERT into shopping_progress |
+| `/shopping_progress_uncheck` | POST | Unmark item | DELETE from shopping_progress |
+| `/shopping_progress` | GET | Get checked items | SELECT from shopping_progress |
+
+All follow the existing pattern: Webhook (responseMode: responseNode) → MySQL → Respond to Webhook (with CORS `*`).
+
+---
+
+## 5. Component Changes
+
+| Component | Change | Risk Level |
+|-----------|--------|------------|
+| **App.js** | Fetch selectedMeals from DB on mount (stale-while-revalidate). Add loading state. Normalize DB response to match existing prop shape. Remove localStorage useEffect for selectedMeals. | LOW |
+| **ChatBot.js** | Add meal: call `/add_weekly_selection` first, update state from response. Remove meal: call `/remove_weekly_selection`. Session ID: deterministic with legacy fallback. | MEDIUM |
+| **MealCreator.js** | Already saves to DB via `/meal_creator_save`. Ensure setSelectedMeals updates from DB response. Session ID: deterministic with legacy fallback. | LOW |
+| **InStoreMode.js** | Replace `inStoreCheckedItems` localStorage with shopping_progress API. Keep localStorage as offline fallback. | MEDIUM |
+| **Home.js** | No change — already fetches from DB endpoint. | NONE |
+| **RecipeInstructions.js** | No change — already has DB fallback. | NONE |
+| **Plan.js** | No change — planTabState stays in localStorage. | NONE |
+| **RecipeIngredients.js** | Remove dead `n8n_recipe_ingredients` localStorage cleanup code. | NONE |
+
+---
+
+## 6. Downstream Risk Analysis
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| **Network latency on App mount** | Brief loading state before meals appear | Stale-while-revalidate: show localStorage cache instantly, update when DB responds |
+| **ChatBot mutation latency** | Add/remove meal feels slower (DB round-trip) | Toast "Saving..." feedback. DB round-trip is ~200ms via n8n. |
+| **Offline shopping** | Can't check/uncheck items without network | Keep localStorage as offline fallback for InStoreMode. Sync on reconnect. |
+| **selectedMeals shape change** | Components expect `meal.name`, DB returns `recipe_name` | Normalization layer in App.js maps DB shape to existing interface |
+| **Session ID migration** | Lose current-week chat history if session ID changes | Check localStorage first, keep existing ID if found for current week |
+| **ChatBot ingredient tracking** | ChatBot stores `ingredients[]` on meal objects in localStorage; DB doesn't have this | Ingredients are fetched on-demand from DB via `/get_recipe_items`. Not needed on the meal object. |
+| **RecipeIngredients.js** | Sends `selectedMeals` JSON to n8n for ingredient extraction | Still works — meal objects will have `name` and `recipeId`, which is all the webhook needs |
+
+---
+
+## 7. Migration Sequence
+
+1. Create `shopping_progress` table (n8n migration workflow)
+2. Create 5 new n8n webhook workflows
+3. Update App.js (DB-first fetch, normalization layer, remove localStorage write)
+4. Update ChatBot.js (DB-first mutations, deterministic session ID)
+5. Update MealCreator.js (ensure DB response drives state, deterministic session ID)
+6. Update InStoreMode.js (shopping_progress API)
+7. Clean up dead code (RecipeIngredients.js localStorage removals)
+8. Test end-to-end on localhost
+9. Deploy and verify on Netlify

--- a/docs/plans/2026-03-08-localstorage-to-db-plan.md
+++ b/docs/plans/2026-03-08-localstorage-to-db-plan.md
@@ -1,0 +1,884 @@
+# LocalStorage → Database Migration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Migrate localStorage-backed state to DB-backed state for multi-device sync, using the DB as single source of truth and localStorage as stale-while-revalidate cache.
+
+**Architecture:** DB-First with localStorage cache. Mutations go through n8n webhooks to MySQL first, then update React state from the DB response. Existing `weekly_selections` + `recipe_summary` tables store meal selections. New `shopping_progress` table stores in-store checked items. Session IDs become deterministic (computed, not stored).
+
+**Tech Stack:** React (CRA), n8n webhooks (MySQL), MySQL 8 (`hsa` database on localhost:3307)
+
+**Design doc:** `docs/plans/2026-03-08-localstorage-to-db-design.md`
+
+---
+
+## Task 1: Create `shopping_progress` Table
+
+**Files:**
+- n8n workflow (new migration workflow)
+
+**Step 1: Create the n8n migration workflow**
+
+Create a new n8n workflow named `Create shopping_progress Table` with this structure:
+- Manual Trigger node
+- MySQL node with credential ID `lqIXlvVVqfE4v7DF` running:
+
+```sql
+CREATE TABLE IF NOT EXISTS shopping_progress (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  week_start_date VARCHAR(20) NOT NULL,
+  item_id INT NOT NULL,
+  checked_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_week_item (week_start_date, item_id)
+);
+```
+
+**Step 2: Execute the migration**
+
+Run the workflow manually via n8n UI. Verify table exists:
+```sql
+DESCRIBE shopping_progress;
+```
+
+**Step 3: Deactivate the migration workflow**
+
+Deactivate after successful run (one-time migration).
+
+---
+
+## Task 2: Create n8n Webhook — `GET /fetch_weekly_meals`
+
+This endpoint fetches the current week's selected meals with rich recipe data. While `chooseRecipeInstructions` already exists, we need a dedicated endpoint that returns the normalized shape App.js expects (including `recipe_description`, `prep_time_minutes`, etc. from `recipe_summary`).
+
+**Files:**
+- n8n workflow (new)
+
+**Step 1: Create the n8n workflow**
+
+Name: `Fetch Weekly Meals`
+Structure: Webhook (GET, path: `fetch_weekly_meals`, responseMode: `responseNode`) → MySQL → Respond to Webhook
+
+**CRITICAL:** Add a `webhookId` property (any UUID, e.g. `c1d2e3f4-a5b6-7890-cdef-1234567890ab`) to the Webhook node.
+
+MySQL query:
+```sql
+SELECT
+  ws.selection_id,
+  ws.WeekDateRange,
+  ws.recipe_id,
+  ws.notes,
+  ws.created_at,
+  rs.recipe_name,
+  rs.recipe_description,
+  rs.prep_time_minutes,
+  rs.cook_time_minutes,
+  rs.total_time_minutes,
+  rs.servings,
+  rs.difficulty_level,
+  rs.tags
+FROM weekly_selections ws
+LEFT JOIN recipe_summary rs ON ws.recipe_id = rs.recipe_id
+WHERE ws.WeekDateRange = '{{ $json.query.weekDateRange }}'
+ORDER BY ws.created_at ASC
+```
+
+Respond to Webhook: return the MySQL results array with CORS headers `Access-Control-Allow-Origin: *`.
+
+**Step 2: Test the endpoint**
+
+```
+GET https://n8n-grocery.needexcelexpert.com/webhook/fetch_weekly_meals?weekDateRange=For+the+week+of+March+8th+to+March+14th%2C+2026
+```
+
+Expected: Array of meal objects with `recipe_name`, `recipe_description`, `prep_time_minutes`, etc.
+
+**Step 3: Activate the workflow**
+
+Deactivate then reactivate to register the webhookId.
+
+---
+
+## Task 3: Create n8n Webhook — `POST /add_weekly_selection`
+
+**Files:**
+- n8n workflow (new)
+
+**Step 1: Create the n8n workflow**
+
+Name: `Add Weekly Selection`
+Structure: Webhook (POST, path: `add_weekly_selection`, responseMode: `responseNode`) → MySQL INSERT → MySQL SELECT (return updated list) → Respond to Webhook
+
+**CRITICAL:** Add `webhookId` (e.g. `d2e3f4a5-b6c7-8901-defg-234567890abc`).
+
+MySQL INSERT:
+```sql
+INSERT INTO weekly_selections (WeekDateRange, recipe_id, notes)
+VALUES ('{{ $json.body.weekDateRange }}', {{ $json.body.recipeId }}, '{{ $json.body.notes || "" }}')
+```
+
+MySQL SELECT (return updated list — same query as Task 2):
+```sql
+SELECT
+  ws.selection_id,
+  ws.WeekDateRange,
+  ws.recipe_id,
+  ws.notes,
+  ws.created_at,
+  rs.recipe_name,
+  rs.recipe_description,
+  rs.prep_time_minutes,
+  rs.cook_time_minutes,
+  rs.total_time_minutes,
+  rs.servings,
+  rs.difficulty_level,
+  rs.tags
+FROM weekly_selections ws
+LEFT JOIN recipe_summary rs ON ws.recipe_id = rs.recipe_id
+WHERE ws.WeekDateRange = '{{ $json.body.weekDateRange }}'
+ORDER BY ws.created_at ASC
+```
+
+Respond to Webhook: return the SELECT results array with CORS `*`.
+
+**Step 2: Test**
+
+```
+POST /add_weekly_selection
+Body: { "weekDateRange": "For the week of March 8th to March 14th, 2026", "recipeId": 45, "notes": "" }
+```
+
+Expected: Returns full updated meals array.
+
+---
+
+## Task 4: Create n8n Webhook — `POST /remove_weekly_selection`
+
+**Files:**
+- n8n workflow (new)
+
+**Step 1: Create the n8n workflow**
+
+Name: `Remove Weekly Selection`
+Structure: Webhook (POST, path: `remove_weekly_selection`, responseMode: `responseNode`) → MySQL DELETE → MySQL SELECT (return updated list) → Respond to Webhook
+
+**CRITICAL:** Add `webhookId` (e.g. `e3f4a5b6-c7d8-9012-efgh-34567890abcd`).
+
+MySQL DELETE:
+```sql
+DELETE FROM weekly_selections
+WHERE recipe_id = {{ $json.body.recipeId }}
+  AND WeekDateRange = '{{ $json.body.weekDateRange }}'
+LIMIT 1
+```
+
+MySQL SELECT: Same query as Task 2/3 (return remaining meals for the week).
+
+Set `alwaysOutputData: true` on both MySQL nodes (handles 0-row results).
+
+Respond to Webhook: return the SELECT results (may be empty array) with CORS `*`.
+
+**Step 2: Test**
+
+```
+POST /remove_weekly_selection
+Body: { "weekDateRange": "For the week of March 8th to March 14th, 2026", "recipeId": 45 }
+```
+
+Expected: Returns updated meals array (without the removed meal).
+
+---
+
+## Task 5: Create n8n Webhooks — Shopping Progress (3 endpoints)
+
+**Files:**
+- n8n workflow (new, single workflow with 3 webhook paths)
+
+**Step 1: Create `GET /shopping_progress` workflow**
+
+Name: `Shopping Progress`
+Structure: Webhook (GET, path: `shopping_progress`, responseMode: `responseNode`) → MySQL SELECT → Respond to Webhook
+
+**CRITICAL:** Add `webhookId` (e.g. `f4a5b6c7-d8e9-0123-fghi-4567890abcde`).
+
+MySQL:
+```sql
+SELECT item_id, checked_at
+FROM shopping_progress
+WHERE week_start_date = '{{ $json.query.week_start_date }}'
+```
+
+**Step 2: Create `POST /shopping_progress_check` workflow**
+
+Name: `Shopping Progress Check`
+Structure: Webhook (POST, path: `shopping_progress_check`, responseMode: `responseNode`) → MySQL INSERT → Respond to Webhook
+
+**CRITICAL:** Add `webhookId`.
+
+MySQL:
+```sql
+INSERT IGNORE INTO shopping_progress (week_start_date, item_id)
+VALUES ('{{ $json.body.week_start_date }}', {{ $json.body.item_id }})
+```
+
+Respond with `{ "success": true }`.
+
+**Step 3: Create `POST /shopping_progress_uncheck` workflow**
+
+Name: `Shopping Progress Uncheck`
+Structure: Webhook (POST, path: `shopping_progress_uncheck`, responseMode: `responseNode`) → MySQL DELETE → Respond to Webhook
+
+**CRITICAL:** Add `webhookId`.
+
+MySQL:
+```sql
+DELETE FROM shopping_progress
+WHERE week_start_date = '{{ $json.body.week_start_date }}'
+  AND item_id = {{ $json.body.item_id }}
+```
+
+Respond with `{ "success": true }`.
+
+**Step 4: Activate all three workflows**
+
+Deactivate then reactivate each.
+
+---
+
+## Task 6: Add New Endpoints to `api.js`
+
+**Files:**
+- Modify: `src/config/api.js:17-86`
+
+**Step 1: Add the new endpoint URLs**
+
+Add these lines to the ENDPOINTS object in `src/config/api.js`, after the existing `chooseRecipeInstructions` line (line 35):
+
+```javascript
+  // Weekly meal selections (DB-backed)
+  fetchWeeklyMeals: `${API_BASE_URL}/fetch_weekly_meals`,
+  addWeeklySelection: `${API_BASE_URL}/add_weekly_selection`,
+  removeWeeklySelection: `${API_BASE_URL}/remove_weekly_selection`,
+
+  // Shopping progress (DB-backed)
+  shoppingProgress: `${API_BASE_URL}/shopping_progress`,
+  shoppingProgressCheck: `${API_BASE_URL}/shopping_progress_check`,
+  shoppingProgressUncheck: `${API_BASE_URL}/shopping_progress_uncheck`,
+```
+
+**Step 2: Verify no import changes needed**
+
+The `ENDPOINTS` object is already exported. No other changes needed.
+
+**Step 3: Commit**
+
+```bash
+git add src/config/api.js
+git commit -m "feat: add DB-backed endpoints for weekly meals and shopping progress"
+```
+
+---
+
+## Task 7: Add `normalizeDbMeals` Utility
+
+**Files:**
+- Modify: `src/config/api.js` (add utility function at bottom, before final export)
+
+**Step 1: Add the normalizer function**
+
+Add after the `showApiError` function (after line 183), before the final export:
+
+```javascript
+/**
+ * Normalize DB meal response to match the component prop interface.
+ * DB returns: { selection_id, recipe_id, recipe_name, recipe_description, ... }
+ * Components expect: { id, name, recipeId, description, ... }
+ */
+export function normalizeDbMeals(dbRows) {
+  if (!Array.isArray(dbRows)) return [];
+  return dbRows.map(row => ({
+    id: row.selection_id,
+    name: row.recipe_name,
+    recipeId: String(row.recipe_id),
+    description: row.recipe_description || row.notes || '',
+    prepTime: row.prep_time_minutes,
+    cookTime: row.cook_time_minutes,
+    totalTime: row.total_time_minutes,
+    servings: row.servings,
+    difficulty: row.difficulty_level,
+    tags: row.tags,
+    ingredients: [],
+  }));
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/config/api.js
+git commit -m "feat: add normalizeDbMeals utility for DB response mapping"
+```
+
+---
+
+## Task 8: Update App.js — DB-First selectedMeals
+
+**Files:**
+- Modify: `src/components/App.js:1-89` (imports, state init, useEffect)
+
+**Step 1: Add imports**
+
+At the top of App.js (line 1), add `normalizeDbMeals` to the import from api.js. Find the existing import (there may not be one from api.js in App.js — check). If no existing import, add:
+
+```javascript
+import { ENDPOINTS, apiFetch, normalizeDbMeals } from "../config/api";
+```
+
+**Step 2: Replace selectedMeals useState initializer (lines 62-70)**
+
+Replace the current localStorage-based initializer with a stale-while-revalidate pattern:
+
+```javascript
+  // Initialize from localStorage cache (stale-while-revalidate)
+  const [selectedMeals, setSelectedMeals] = useState(() => {
+    try {
+      const weekKey = `selectedMeals_${getWeekDates().startDate}`;
+      const stored = localStorage.getItem(weekKey);
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  });
+  const [mealsLoading, setMealsLoading] = useState(true);
+```
+
+Note: Keep the localStorage init for instant display. We'll add a DB fetch useEffect next.
+
+**Step 3: Replace the localStorage persistence useEffect (lines 79-89)**
+
+Replace with a DB-fetch-on-mount + cache-write pattern:
+
+```javascript
+  // Fetch selectedMeals from DB on mount (stale-while-revalidate)
+  useEffect(() => {
+    const fetchMeals = async () => {
+      try {
+        const weekData = getWeekDates();
+        const url = new URL(ENDPOINTS.fetchWeeklyMeals);
+        url.searchParams.append("weekDateRange", weekData.displayRange);
+        const response = await apiFetch(url.toString(), {
+          method: "GET",
+          headers: { Accept: "application/json" },
+        });
+        if (response.ok) {
+          const data = await response.json();
+          const normalized = normalizeDbMeals(data);
+          setSelectedMeals(normalized);
+          // Update localStorage cache
+          const weekKey = `selectedMeals_${weekData.startDate}`;
+          if (normalized.length > 0) {
+            localStorage.setItem(weekKey, JSON.stringify(normalized));
+          } else {
+            localStorage.removeItem(weekKey);
+          }
+        }
+      } catch {
+        // Keep stale localStorage data on network failure
+      } finally {
+        setMealsLoading(false);
+      }
+    };
+    fetchMeals();
+  }, []);
+```
+
+**Step 4: Add a `refreshMeals` callback for children to call after mutations**
+
+Add after the useEffect above:
+
+```javascript
+  // Callback for children to refresh meals from DB after mutations
+  const refreshMeals = useCallback(async () => {
+    try {
+      const weekData = getWeekDates();
+      const url = new URL(ENDPOINTS.fetchWeeklyMeals);
+      url.searchParams.append("weekDateRange", weekData.displayRange);
+      const response = await apiFetch(url.toString(), {
+        method: "GET",
+        headers: { Accept: "application/json" },
+      });
+      if (response.ok) {
+        const data = await response.json();
+        const normalized = normalizeDbMeals(data);
+        setSelectedMeals(normalized);
+        const weekKey = `selectedMeals_${weekData.startDate}`;
+        if (normalized.length > 0) {
+          localStorage.setItem(weekKey, JSON.stringify(normalized));
+        } else {
+          localStorage.removeItem(weekKey);
+        }
+      }
+    } catch { /* silent — stale data is better than no data */ }
+  }, []);
+```
+
+**Step 5: Pass `refreshMeals` as prop to components that mutate meals**
+
+In the renderScreen function, add `refreshMeals` prop to:
+- `Plan` component (case "plan", line ~166): add `refreshMeals={refreshMeals}`
+- `ChatBot` component (case "chatbot", line ~181): add `refreshMeals={refreshMeals}`
+- `MealCreator` component (case "meal-creator", line ~193): add `refreshMeals={refreshMeals}`
+
+**Step 6: Verify build**
+
+```bash
+cd "C:/New Grocery App/grocery-checklist-app" && npm run build
+```
+
+Expected: Build succeeds (components don't use refreshMeals yet, so unused prop is fine).
+
+**Step 7: Commit**
+
+```bash
+git add src/components/App.js
+git commit -m "feat: fetch selectedMeals from DB on mount with stale-while-revalidate cache"
+```
+
+---
+
+## Task 9: Update ChatBot.js — DB-First Mutations + Deterministic Session ID
+
+**Files:**
+- Modify: `src/components/ChatBot.js`
+
+**Step 1: Update the `getSessionId` function (lines 7-17)**
+
+Replace with deterministic ID + legacy fallback:
+
+```javascript
+const getSessionId = () => {
+  const weekStart = getWeekDates().startDate;
+  const storageKey = `chatSessionId_${weekStart}`;
+  // Legacy fallback: if existing random session ID for this week, keep using it
+  const existing = localStorage.getItem(storageKey);
+  if (existing) return existing;
+  // New deterministic format — same on any device
+  const sessionId = `chat_${weekStart}`;
+  return sessionId;
+};
+```
+
+**Step 2: Add `refreshMeals` to the destructured props (line 22)**
+
+Find the component signature:
+```javascript
+const ChatBot = ({ onBack, onNavigate, selectedMeals: parentSelectedMeals, setSelectedMeals: setParentSelectedMeals, groceryListData, setGroceryListData, debugMode = false }) => {
+```
+
+Add `refreshMeals` to it:
+```javascript
+const ChatBot = ({ onBack, onNavigate, selectedMeals: parentSelectedMeals, setSelectedMeals: setParentSelectedMeals, refreshMeals, groceryListData, setGroceryListData, debugMode = false }) => {
+```
+
+**Step 3: Add import for ENDPOINTS and apiFetch**
+
+Check if ChatBot.js already imports from api.js. If not, add:
+```javascript
+import { ENDPOINTS, apiFetch } from "../config/api";
+```
+
+**Step 4: Update `addMealToList` (lines 241-256) to persist to DB first**
+
+Replace the function body:
+
+```javascript
+  const addMealToList = async (mealName, mealDescription, recipeId = null, totalTime = null) => {
+    if (!recipeId) {
+      addDebugLog('⚠️ Cannot add meal without recipeId');
+      return;
+    }
+    try {
+      const weekData = getWeekDates();
+      const response = await apiFetch(ENDPOINTS.addWeeklySelection, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          weekDateRange: weekData.displayRange,
+          recipeId: Number(recipeId),
+          notes: '',
+        }),
+      });
+      if (response.ok) {
+        if (refreshMeals) await refreshMeals();
+        toast.success(`Added "${mealName}" to this week!`);
+        addDebugLog('Added meal to DB and refreshed:', mealName);
+      } else {
+        toast.error(`Failed to add "${mealName}".`);
+      }
+    } catch (error) {
+      toast.error(`Failed to add "${mealName}". Check connection.`);
+      addDebugLog('Error adding meal:', error.message);
+    }
+  };
+```
+
+**Step 5: Update `removeMeal` (lines 261-313) to use new endpoint**
+
+The existing `removeMeal` already calls a webhook. Replace the `setSelectedMeals` calls with `refreshMeals`:
+
+Find line 303:
+```javascript
+        setSelectedMeals(prev => prev.filter(m => m.id !== mealId));
+```
+
+Replace with:
+```javascript
+        if (refreshMeals) await refreshMeals();
+```
+
+Also add a call to the new `removeWeeklySelection` endpoint. In the payload section, ADD a call to the dedicated endpoint alongside the existing agent call:
+
+After the existing webhook succeeds (inside the `if (response.ok)` block at ~line 301), add:
+```javascript
+        // Also remove from weekly_selections via dedicated endpoint
+        await apiFetch(ENDPOINTS.removeWeeklySelection, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            weekDateRange: weekData.displayRange,
+            recipeId: Number(mealToRemove.recipeId),
+          }),
+        });
+        if (refreshMeals) await refreshMeals();
+```
+
+**Step 6: Verify build**
+
+```bash
+cd "C:/New Grocery App/grocery-checklist-app" && npm run build
+```
+
+**Step 7: Commit**
+
+```bash
+git add src/components/ChatBot.js
+git commit -m "feat: ChatBot uses DB-first meal mutations and deterministic session ID"
+```
+
+---
+
+## Task 10: Update Plan.js — Pass Through `refreshMeals` Prop
+
+**Files:**
+- Modify: `src/components/Plan.js`
+
+**Step 1: Add `refreshMeals` to destructured props (line ~27)**
+
+Find the Plan component signature and add `refreshMeals`:
+```javascript
+  refreshMeals,
+```
+
+**Step 2: Pass `refreshMeals` to ChatBot and MealCreator children**
+
+Find where Plan renders ChatBot (around line 132) and add the prop:
+```javascript
+  refreshMeals={refreshMeals}
+```
+
+Find where Plan renders MealCreator (around line 144) and add:
+```javascript
+  refreshMeals={refreshMeals}
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/components/Plan.js
+git commit -m "feat: Plan passes refreshMeals prop to ChatBot and MealCreator"
+```
+
+---
+
+## Task 11: Update MealCreator.js — DB-First + Deterministic Session ID
+
+**Files:**
+- Modify: `src/components/MealCreator.js`
+
+**Step 1: Update `getCreatorSessionId` function (lines 7-17)**
+
+Replace with deterministic + legacy fallback:
+
+```javascript
+const getCreatorSessionId = () => {
+  const weekStart = getWeekDates().startDate;
+  const storageKey = `creatorSessionId_${weekStart}`;
+  // Legacy fallback: keep existing random ID for current week
+  const existing = localStorage.getItem(storageKey);
+  if (existing) return existing;
+  // New deterministic format
+  const sessionId = `creator_${weekStart}`;
+  return sessionId;
+};
+```
+
+**Step 2: Add `refreshMeals` to destructured props (line 26)**
+
+```javascript
+const MealCreator = ({ onBack, onNavigate, selectedMeals, setSelectedMeals, refreshMeals, debugMode = false }) => {
+```
+
+**Step 3: Update `addToThisWeek` — replace `setSelectedMeals` with `refreshMeals` (line ~436)**
+
+Find line 436:
+```javascript
+        setSelectedMeals(prev => [...prev, newMeal]);
+```
+
+Replace with:
+```javascript
+        if (refreshMeals) await refreshMeals();
+```
+
+The MealCreator's `addToThisWeek` already calls a webhook that saves to `weekly_selections`. So the DB write is already happening — we just need to refresh from DB instead of optimistically updating local state.
+
+**Step 4: Fix legacy `startOver` session ID (line 540)**
+
+Find the `startOver` function (line ~533). Replace line 540:
+```javascript
+    localStorage.setItem('creatorSessionId', newSessionId);
+```
+
+With:
+```javascript
+    const weekStart = getWeekDates().startDate;
+    localStorage.setItem(`creatorSessionId_${weekStart}`, newSessionId);
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/components/MealCreator.js
+git commit -m "feat: MealCreator uses refreshMeals and deterministic session ID"
+```
+
+---
+
+## Task 12: Update InStoreMode.js — DB-Backed Shopping Progress
+
+**Files:**
+- Modify: `src/components/InStoreMode.js`
+
+**Step 1: Add imports**
+
+Add at top of file (if not already present):
+```javascript
+import { ENDPOINTS, apiFetch } from "../config/api";
+import { getWeekDates } from "../utils/weekDates";
+```
+
+**Step 2: Replace the checked items load useEffect (lines 236-248)**
+
+Replace the localStorage-based load with a DB-first + localStorage fallback:
+
+```javascript
+  // Load checked items from DB, fall back to localStorage
+  useEffect(() => {
+    if (!shoppingList) return;
+
+    const loadCheckedItems = async () => {
+      try {
+        const weekData = getWeekDates();
+        const url = new URL(ENDPOINTS.shoppingProgress);
+        url.searchParams.append("week_start_date", weekData.startDate);
+        const response = await apiFetch(url.toString(), {
+          method: "GET",
+          headers: { Accept: "application/json" },
+        });
+        if (response.ok) {
+          const data = await response.json();
+          const checkedIds = Array.isArray(data) ? data.map(row => row.item_id) : [];
+          setCheckedItems(new Set(checkedIds));
+          return;
+        }
+      } catch {
+        // Fall through to localStorage fallback
+      }
+
+      // Offline fallback: try localStorage
+      try {
+        const stored = localStorage.getItem("inStoreCheckedItems");
+        if (stored) {
+          const parsed = JSON.parse(stored);
+          if (parsed.savedAt === shoppingList.savedAt) {
+            setCheckedItems(new Set(parsed.checkedIds));
+          } else {
+            localStorage.removeItem("inStoreCheckedItems");
+          }
+        }
+      } catch {
+        localStorage.removeItem("inStoreCheckedItems");
+      }
+    };
+
+    loadCheckedItems();
+  }, [shoppingList]);
+```
+
+**Step 3: Update `handleToggleItem` (lines 316-341)**
+
+Replace with DB-first + localStorage cache:
+
+```javascript
+  const handleToggleItem = useCallback(
+    (itemId) => {
+      setCheckedItems((prev) => {
+        const next = new Set(prev);
+        const isChecking = !next.has(itemId);
+
+        if (isChecking) {
+          next.add(itemId);
+        } else {
+          next.delete(itemId);
+        }
+
+        // Persist to DB (fire-and-forget, don't block UI)
+        const weekData = getWeekDates();
+        const endpoint = isChecking
+          ? ENDPOINTS.shoppingProgressCheck
+          : ENDPOINTS.shoppingProgressUncheck;
+        apiFetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            week_start_date: weekData.startDate,
+            item_id: itemId,
+          }),
+        }).catch(() => {
+          // Silently fail — localStorage is backup
+        });
+
+        // Also cache to localStorage (offline backup)
+        if (shoppingList) {
+          localStorage.setItem(
+            "inStoreCheckedItems",
+            JSON.stringify({
+              savedAt: shoppingList.savedAt,
+              checkedIds: Array.from(next),
+            })
+          );
+        }
+
+        return next;
+      });
+    },
+    [shoppingList]
+  );
+```
+
+**Step 4: Verify build**
+
+```bash
+cd "C:/New Grocery App/grocery-checklist-app" && npm run build
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/components/InStoreMode.js
+git commit -m "feat: InStoreMode uses DB-backed shopping progress with localStorage fallback"
+```
+
+---
+
+## Task 13: Clean Up Dead Code
+
+**Files:**
+- Modify: `src/components/RecipeIngredients.js:56-61`
+
+**Step 1: Remove dead localStorage cleanup**
+
+Find and remove these lines (around lines 56-61):
+```javascript
+  // Clear any cached data on component mount
+  useEffect(() => {
+    // Remove any cached webhook responses to ensure fresh data
+    localStorage.removeItem('n8n_recipe_ingredients');
+    localStorage.removeItem('n8n_recipe_ingredients_raw');
+    addDebugLog('🧹 Cleared cached webhook data to ensure fresh responses');
+  }, []);
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/components/RecipeIngredients.js
+git commit -m "chore: remove dead localStorage cleanup for n8n_recipe_ingredients"
+```
+
+---
+
+## Task 14: End-to-End Testing
+
+**Step 1: Start dev server**
+
+```bash
+cd "C:/New Grocery App/grocery-checklist-app" && npm start
+```
+
+**Step 2: Test selectedMeals flow**
+
+1. Open app → Home should show correct meal count (fetched from DB)
+2. Navigate to Plan → Meals tab → ChatBot
+3. Add a meal via ChatBot → verify it appears in the meal panel
+4. Refresh the page → verify meal persists (loaded from DB, not just localStorage)
+5. Open in incognito/another browser → verify same meals appear (multi-device sync)
+6. Remove a meal → verify it disappears and stays gone after refresh
+
+**Step 3: Test shopping progress flow**
+
+1. Navigate to Plan → select items → Start Shopping
+2. In Shop mode, check off a few items
+3. Refresh the page → verify checked items persist
+4. Open in incognito → verify same checked items (multi-device sync)
+5. Uncheck an item → refresh → verify it's unchecked
+
+**Step 4: Test session ID migration**
+
+1. If you have an existing chat session for this week, verify it still loads (legacy fallback)
+2. Clear localStorage chatSessionId key → reload → verify deterministic ID works
+3. Chat should start fresh (new deterministic session has no history)
+
+**Step 5: Test offline fallback**
+
+1. Start shopping, check some items
+2. Disable network (DevTools → Offline)
+3. Check/uncheck items → should still work (localStorage fallback)
+4. Re-enable network → items should persist on next load
+
+**Step 6: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: complete localStorage to DB migration for multi-device sync"
+```
+
+---
+
+## Summary of All Changes
+
+| File | Type | Description |
+|------|------|-------------|
+| `shopping_progress` table | NEW | Stores checked items per shopping session |
+| n8n `Fetch Weekly Meals` | NEW | GET endpoint, weekly_selections JOIN recipe_summary |
+| n8n `Add Weekly Selection` | NEW | POST, inserts meal to weekly_selections, returns list |
+| n8n `Remove Weekly Selection` | NEW | POST, deletes from weekly_selections, returns list |
+| n8n `Shopping Progress` | NEW | GET, returns checked items for week |
+| n8n `Shopping Progress Check` | NEW | POST, marks item checked |
+| n8n `Shopping Progress Uncheck` | NEW | POST, unmarks item |
+| `src/config/api.js` | MODIFY | Add 6 new endpoint URLs + normalizeDbMeals utility |
+| `src/components/App.js` | MODIFY | DB-first fetch on mount, refreshMeals callback, stale-while-revalidate |
+| `src/components/ChatBot.js` | MODIFY | DB-first mutations, deterministic session ID |
+| `src/components/Plan.js` | MODIFY | Pass through refreshMeals prop |
+| `src/components/MealCreator.js` | MODIFY | refreshMeals after save, deterministic session ID, fix legacy startOver |
+| `src/components/InStoreMode.js` | MODIFY | DB-backed shopping progress with localStorage fallback |
+| `src/components/RecipeIngredients.js` | MODIFY | Remove dead localStorage cleanup |

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,6 +4,7 @@ import { Toaster } from "react-hot-toast";
 import { motion, AnimatePresence } from "framer-motion";
 import { getWeekDates } from "../utils/weekDates";
 import { pageTransition } from "../utils/animations";
+import { ENDPOINTS, apiFetch, normalizeDbMeals } from "../config/api";
 import { ThemeProvider } from "../contexts/ThemeContext";
 import AppShell from "./AppShell";
 import Home from "./Home";
@@ -68,6 +69,7 @@ const App = () => {
       return [];
     }
   });
+  const [mealsLoading, setMealsLoading] = useState(true);
   const [groceryListData, setGroceryListData] = useState(null);
   const [inStoreData, setInStoreData] = useState(null);
   const hasUnsavedChangesRef = useRef(false);
@@ -76,17 +78,40 @@ const App = () => {
     hasUnsavedChangesRef.current = value;
   }, []);
 
-  // Persist selectedMeals to localStorage (keyed by week so it auto-resets)
-  useEffect(() => {
+  // Shared helper: fetch meals from DB, normalize, and cache to localStorage
+  const loadMealsFromDb = useCallback(async ({ showLoading = false } = {}) => {
+    if (showLoading) setMealsLoading(true);
     try {
-      const weekKey = `selectedMeals_${getWeekDates().startDate}`;
-      if (selectedMeals.length > 0) {
-        localStorage.setItem(weekKey, JSON.stringify(selectedMeals));
-      } else {
-        localStorage.removeItem(weekKey);
+      const weekData = getWeekDates();
+      const url = new URL(ENDPOINTS.fetchWeeklyMeals);
+      url.searchParams.append("weekDateRange", weekData.displayRange);
+      const response = await apiFetch(url.toString(), {
+        method: "GET",
+        headers: { Accept: "application/json" },
+      });
+      if (response.ok) {
+        const data = await response.json();
+        const normalized = normalizeDbMeals(data);
+        setSelectedMeals(normalized);
+        const weekKey = `selectedMeals_${weekData.startDate}`;
+        if (normalized.length > 0) {
+          localStorage.setItem(weekKey, JSON.stringify(normalized));
+        } else {
+          localStorage.removeItem(weekKey);
+        }
       }
-    } catch { /* ignore storage errors */ }
-  }, [selectedMeals]);
+    } catch {
+      // Keep stale localStorage data on network failure
+    } finally {
+      if (showLoading) setMealsLoading(false);
+    }
+  }, []);
+
+  // Fetch selectedMeals from DB on mount (stale-while-revalidate)
+  useEffect(() => { loadMealsFromDb({ showLoading: true }); }, [loadMealsFromDb]);
+
+  // Callback for children to refresh meals from DB after mutations
+  const refreshMeals = useCallback(() => loadMealsFromDb(), [loadMealsFromDb]);
 
   // Navigate with unsaved-changes confirmation and browser history push
   const navigateToScreen = useCallback((screen) => {
@@ -169,6 +194,7 @@ const App = () => {
             onStartShopping={handleStartShopping}
             selectedMeals={selectedMeals}
             setSelectedMeals={setSelectedMeals}
+            refreshMeals={refreshMeals}
             groceryListData={groceryListData}
             setGroceryListData={setGroceryListData}
             debugMode={debugMode}
@@ -183,6 +209,7 @@ const App = () => {
             onNavigate={navigateToScreen}
             selectedMeals={selectedMeals}
             setSelectedMeals={setSelectedMeals}
+            refreshMeals={refreshMeals}
             groceryListData={groceryListData}
             setGroceryListData={setGroceryListData}
             debugMode={debugMode}
@@ -195,6 +222,7 @@ const App = () => {
             onNavigate={navigateToScreen}
             selectedMeals={selectedMeals}
             setSelectedMeals={setSelectedMeals}
+            refreshMeals={refreshMeals}
             debugMode={debugMode}
           />
         );

--- a/src/components/ChatBot.js
+++ b/src/components/ChatBot.js
@@ -8,18 +8,18 @@ import { ENDPOINTS, apiFetch } from '../config/api';
 const getSessionId = () => {
   const weekStart = getWeekDates().startDate;
   const storageKey = `chatSessionId_${weekStart}`;
-  let sessionId = localStorage.getItem(storageKey);
-  if (!sessionId) {
-    sessionId = `session_${weekStart}_${Math.random().toString(36).substr(2, 9)}`;
-    localStorage.setItem(storageKey, sessionId);
-  }
+  // Legacy fallback: if existing random session ID for this week, keep using it
+  const existing = localStorage.getItem(storageKey);
+  if (existing) return existing;
+  // New deterministic format — same on any device
+  const sessionId = `chat_${weekStart}`;
   return sessionId;
 };
 
 const CHATBOT_WEBHOOK_URL = ENDPOINTS.callGroceryAgent;
 const CHAT_HISTORY_URL = ENDPOINTS.chatHistory;
 
-const ChatBot = ({ onBack, onNavigate, selectedMeals: parentSelectedMeals, setSelectedMeals: setParentSelectedMeals, groceryListData, setGroceryListData, debugMode = false }) => {
+const ChatBot = ({ onBack, onNavigate, selectedMeals: parentSelectedMeals, setSelectedMeals: setParentSelectedMeals, refreshMeals, groceryListData, setGroceryListData, debugMode = false }) => {
   // Session management
   const [sessionId] = useState(getSessionId());
 
@@ -238,21 +238,33 @@ const ChatBot = ({ onBack, onNavigate, selectedMeals: parentSelectedMeals, setSe
   };
 
   // Add a meal to the selected meals list
-  const addMealToList = (mealName, mealDescription, recipeId = null, totalTime = null) => {
-    const newMeal = {
-      id: Date.now(),
-      name: mealName,
-      description: mealDescription,
-      recipeId: recipeId,
-      totalTime: totalTime,
-      ingredients: []
-    };
-
-    setSelectedMeals(prev => [...prev, newMeal]);
-
-    // Removed automatic ingredient fetching since we're not showing ingredients in side panel
-
-    addDebugLog('Added meal to planning list:', newMeal);
+  const addMealToList = async (mealName, mealDescription, recipeId = null, totalTime = null) => {
+    if (!recipeId) {
+      addDebugLog('⚠️ Cannot add meal without recipeId');
+      return;
+    }
+    try {
+      const weekData = getWeekDates();
+      const response = await apiFetch(ENDPOINTS.addWeeklySelection, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          weekDateRange: weekData.displayRange,
+          recipeId: Number(recipeId),
+          notes: '',
+        }),
+      });
+      if (response.ok) {
+        if (refreshMeals) await refreshMeals();
+        toast.success(`Added "${mealName}" to this week!`);
+        addDebugLog('Added meal to DB and refreshed:', mealName);
+      } else {
+        toast.error(`Failed to add "${mealName}".`);
+      }
+    } catch (error) {
+      toast.error(`Failed to add "${mealName}". Check connection.`);
+      addDebugLog('Error adding meal:', error.message);
+    }
   };
 
   // Removed ingredient fetching since we're not showing ingredients in side panel
@@ -300,8 +312,17 @@ const ChatBot = ({ onBack, onNavigate, selectedMeals: parentSelectedMeals, setSe
 
       if (response.ok) {
         addDebugLog('✅ Delete meal webhook call successful');
-        setSelectedMeals(prev => prev.filter(m => m.id !== mealId));
-        addDebugLog('Removed meal from planning list:', mealId);
+        // Also remove from weekly_selections via dedicated endpoint
+        await apiFetch(ENDPOINTS.removeWeeklySelection, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            weekDateRange: weekData.displayRange,
+            recipeId: Number(mealToRemove.recipeId),
+          }),
+        });
+        if (refreshMeals) await refreshMeals();
+        addDebugLog('Removed meal from DB and refreshed:', mealId);
       } else {
         addDebugLog('⚠️ Delete meal webhook call failed:', response.status);
         toast.error(`Failed to remove "${mealToRemove.name}". Server returned ${response.status}.`);

--- a/src/components/InStoreMode.js
+++ b/src/components/InStoreMode.js
@@ -229,23 +229,46 @@ const InStoreMode = ({ inStoreData, onExit }) => {
     fetchCurrentWeekItems();
   }, [inStoreData]);
 
-  // Load checked items from localStorage, invalidate if list changed
+  // Load checked items from DB, fall back to localStorage
   useEffect(() => {
     if (!shoppingList) return;
 
-    const stored = localStorage.getItem("inStoreCheckedItems");
-    if (stored) {
+    const loadCheckedItems = async () => {
       try {
-        const parsed = JSON.parse(stored);
-        if (parsed.savedAt === shoppingList.savedAt) {
-          setCheckedItems(new Set(parsed.checkedIds));
-        } else {
-          localStorage.removeItem("inStoreCheckedItems");
+        const weekData = getWeekDates();
+        const url = new URL(ENDPOINTS.shoppingProgress);
+        url.searchParams.append("week_start_date", weekData.startDate);
+        const response = await apiFetch(url.toString(), {
+          method: "GET",
+          headers: { Accept: "application/json" },
+        });
+        if (response.ok) {
+          const data = await response.json();
+          const checkedIds = Array.isArray(data) ? data.map(row => row.item_id) : [];
+          setCheckedItems(new Set(checkedIds));
+          return;
+        }
+      } catch {
+        // Fall through to localStorage fallback
+      }
+
+      // Offline fallback: try localStorage
+      try {
+        const stored = localStorage.getItem("inStoreCheckedItems");
+        if (stored) {
+          const parsed = JSON.parse(stored);
+          if (parsed.savedAt === shoppingList.savedAt) {
+            setCheckedItems(new Set(parsed.checkedIds));
+          } else {
+            localStorage.removeItem("inStoreCheckedItems");
+          }
         }
       } catch {
         localStorage.removeItem("inStoreCheckedItems");
       }
-    }
+    };
+
+    loadCheckedItems();
   }, [shoppingList]);
 
   // Fetch coupon matches for inline reminders
@@ -317,13 +340,31 @@ const InStoreMode = ({ inStoreData, onExit }) => {
     (itemId) => {
       setCheckedItems((prev) => {
         const next = new Set(prev);
-        if (next.has(itemId)) {
-          next.delete(itemId);
-        } else {
+        const isChecking = !next.has(itemId);
+
+        if (isChecking) {
           next.add(itemId);
+        } else {
+          next.delete(itemId);
         }
 
-        // Persist to localStorage
+        // Persist to DB (fire-and-forget, don't block UI)
+        const weekData = getWeekDates();
+        const endpoint = isChecking
+          ? ENDPOINTS.shoppingProgressCheck
+          : ENDPOINTS.shoppingProgressUncheck;
+        apiFetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            week_start_date: weekData.startDate,
+            item_id: itemId,
+          }),
+        }).catch(() => {
+          // Silently fail — localStorage is backup
+        });
+
+        // Also cache to localStorage (offline backup)
         if (shoppingList) {
           localStorage.setItem(
             "inStoreCheckedItems",

--- a/src/components/MealCreator.js
+++ b/src/components/MealCreator.js
@@ -8,11 +8,11 @@ import { ENDPOINTS, apiFetch } from '../config/api';
 const getCreatorSessionId = () => {
   const weekStart = getWeekDates().startDate;
   const storageKey = `creatorSessionId_${weekStart}`;
-  let sessionId = localStorage.getItem(storageKey);
-  if (!sessionId) {
-    sessionId = `creator_${weekStart}_${Math.random().toString(36).substr(2, 9)}`;
-    localStorage.setItem(storageKey, sessionId);
-  }
+  // Legacy fallback: keep existing random ID for current week
+  const existing = localStorage.getItem(storageKey);
+  if (existing) return existing;
+  // New deterministic format
+  const sessionId = `creator_${weekStart}`;
   return sessionId;
 };
 
@@ -23,7 +23,7 @@ const ADD_TO_WEEK_WEBHOOK_URL = ENDPOINTS.callGroceryAgent;
 
 const CHAT_HISTORY_URL = ENDPOINTS.chatHistory;
 
-const MealCreator = ({ onBack, onNavigate, selectedMeals, setSelectedMeals, debugMode = false }) => {
+const MealCreator = ({ onBack, onNavigate, selectedMeals, setSelectedMeals, refreshMeals, debugMode = false }) => {
   const [sessionId] = useState(getCreatorSessionId());
   const [phase, setPhase] = useState(1); // 1=describe, 2=building, 3=preview, 4=saved
   const [messages, setMessages] = useState([
@@ -433,7 +433,7 @@ const MealCreator = ({ onBack, onNavigate, selectedMeals, setSelectedMeals, debu
       });
 
       if (response.ok) {
-        setSelectedMeals(prev => [...prev, newMeal]);
+        if (refreshMeals) await refreshMeals();
         toast.success(`Added to this week's meals!`);
         addDebugLog('Added to weekly_selections:', saveResult.recipeId);
 
@@ -537,7 +537,8 @@ const MealCreator = ({ onBack, onNavigate, selectedMeals, setSelectedMeals, debu
     setSaveResult(null);
     // Create a fresh session ID for new conversation
     const newSessionId = `creator_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-    localStorage.setItem('creatorSessionId', newSessionId);
+    const weekStart = getWeekDates().startDate;
+    localStorage.setItem(`creatorSessionId_${weekStart}`, newSessionId);
     // Reset messages to initial greeting
     setMessages([{
       id: 1,

--- a/src/components/Plan.js
+++ b/src/components/Plan.js
@@ -28,6 +28,7 @@ const Plan = ({
   onStartShopping,
   selectedMeals,
   setSelectedMeals,
+  refreshMeals,
   groceryListData,
   setGroceryListData,
   debugMode,
@@ -131,6 +132,7 @@ const Plan = ({
             onNavigate={handleMealNavigate}
             selectedMeals={selectedMeals}
             setSelectedMeals={setSelectedMeals}
+            refreshMeals={refreshMeals}
             groceryListData={groceryListData}
             setGroceryListData={setGroceryListData}
             debugMode={debugMode}
@@ -143,6 +145,7 @@ const Plan = ({
             onNavigate={handleMealNavigate}
             selectedMeals={selectedMeals}
             setSelectedMeals={setSelectedMeals}
+            refreshMeals={refreshMeals}
             debugMode={debugMode}
           />
         )}

--- a/src/components/RecipeIngredients.js
+++ b/src/components/RecipeIngredients.js
@@ -52,14 +52,6 @@ const RecipeIngredients = ({ selectedMeals = [], onNavigate, groceryListData, de
     console.log(`[${timestamp}] ${message}`, data || "");
   };
 
-  // Clear any cached data on component mount
-  useEffect(() => {
-    // Remove any cached webhook responses to ensure fresh data
-    localStorage.removeItem('n8n_recipe_ingredients');
-    localStorage.removeItem('n8n_recipe_ingredients_raw');
-    addDebugLog('🧹 Cleared cached webhook data to ensure fresh responses');
-  }, []);
-
   // Handle adding ingredients to main list
   const handleAddToMainList = async () => {
     setIsAddingToMainList(true);

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -33,6 +33,17 @@ export const ENDPOINTS = {
   // Recipes
   mealIngredients: `${API_BASE_URL}/meal_ingredients`,
   chooseRecipeInstructions: `${API_BASE_URL}/choose_recipe_instructions`,
+
+  // Weekly meal selections (DB-backed)
+  fetchWeeklyMeals: `${API_BASE_URL}/fetch_weekly_meals`,
+  addWeeklySelection: `${API_BASE_URL}/add_weekly_selection`,
+  removeWeeklySelection: `${API_BASE_URL}/remove_weekly_selection`,
+
+  // Shopping progress (DB-backed)
+  shoppingProgress: `${API_BASE_URL}/shopping_progress`,
+  shoppingProgressCheck: `${API_BASE_URL}/shopping_progress_check`,
+  shoppingProgressUncheck: `${API_BASE_URL}/shopping_progress_uncheck`,
+
   grabInstructionsFast: `${API_BASE_URL}/grab_instructions_fast`,
 
   // Meal Creator
@@ -180,6 +191,28 @@ export function showApiError(error, onRetry) {
   } else {
     toast.error(message, { duration: 4000 });
   }
+}
+
+/**
+ * Normalize DB meal response to match the component prop interface.
+ * DB returns: { selection_id, recipe_id, recipe_name, recipe_description, ... }
+ * Components expect: { id, name, recipeId, description, ... }
+ */
+export function normalizeDbMeals(dbRows) {
+  if (!Array.isArray(dbRows)) return [];
+  return dbRows.map(row => ({
+    id: row.selection_id,
+    name: row.recipe_name,
+    recipeId: String(row.recipe_id),
+    description: row.recipe_description || row.notes || '',
+    prepTime: row.prep_time_minutes,
+    cookTime: row.cook_time_minutes,
+    totalTime: row.total_time_minutes,
+    servings: row.servings,
+    difficulty: row.difficulty_level,
+    tags: row.tags,
+    ingredients: [],
+  }));
 }
 
 export { API_BASE_URL, CLIP_SERVER_URL };


### PR DESCRIPTION
## Summary
- Migrates `selectedMeals` and shopping progress from localStorage-only to MySQL DB as single source of truth, with localStorage retained as offline fallback cache (stale-while-revalidate pattern)
- Adds 6 new n8n webhook endpoints for weekly meal CRUD and shopping progress check/uncheck
- Implements deterministic session IDs for ChatBot/MealCreator for cross-device continuity
- Adds `normalizeDbMeals` utility to map DB column names to React component prop interface
- Removes dead localStorage cleanup code in RecipeIngredients

## Files changed
- `src/config/api.js` — 6 new endpoint URLs + `normalizeDbMeals` utility
- `src/components/App.js` — DB-first fetch on mount, `loadMealsFromDb` shared helper, `refreshMeals` callback
- `src/components/ChatBot.js` — DB-first mutations via `addWeeklySelection`/`removeWeeklySelection`, deterministic session ID
- `src/components/MealCreator.js` — Uses `refreshMeals` after save, deterministic session ID, week-scoped `startOver`
- `src/components/Plan.js` — Passes `refreshMeals` through to ChatBot/MealCreator children
- `src/components/InStoreMode.js` — DB-backed shopping progress (fire-and-forget POST, DB-first GET with localStorage fallback)
- `src/components/RecipeIngredients.js` — Removed dead `n8n_recipe_ingredients` localStorage cleanup
- `docs/plans/` — Design doc and implementation plan

## Test plan
- [x] 16/16 unit tests pass (App.test.js, api.test.js, weekDates.test.js)
- [x] Production build compiles successfully
- [x] `fetch_weekly_meals` endpoint returns array of meals with rich recipe data (200)
- [x] `shopping_progress_check` / `shopping_progress` / `shopping_progress_uncheck` full cycle verified
- [x] Home screen shows correct meal count from DB
- [x] Plan screen renders ChatBot correctly with DB-backed state
- [x] No failed network requests in preview
- [ ] Manual test: add meal via ChatBot, verify it persists across browser refresh
- [ ] Manual test: check items in Shop mode, verify they persist across refresh
- [ ] Manual test: verify offline fallback (disconnect network, check localStorage still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)