### PR TITLE
feat: promote Meals to own tab, fix scroll & nav bugs

### DIFF
--- a/docs/plans/2026-03-23-nav-restructure-bugfix-design.md
+++ b/docs/plans/2026-03-23-nav-restructure-bugfix-design.md
@@ -1,0 +1,97 @@
+# Navigation Restructuring & Bug Fixes Design
+
+**Date:** 2026-03-23
+**Status:** Approved
+**Feedback IDs:** #5 (bug), #6 (bug), #7 (idea)
+
+## Problem Statement
+
+User feedback identified three related issues on the Plan screen:
+
+1. **Bug #5** — Can't scroll the page when touching inside the item list area on mobile. Only scrollable from the far left/right edges.
+2. **Bug #6** — The meal agent sub-menu overlaps the grocery planning header when switching tabs.
+3. **Idea #7** — The 3-level navigation (bottom bar > Plan tabs > Meals sub-tabs) is confusing and difficult to navigate.
+
+All three stem from the Plan screen trying to contain two distinct experiences (grocery list + meal planning) within a single tabbed interface.
+
+## Solution Overview
+
+**Promote Meals to its own bottom bar tab.** This eliminates the nested tab structure, separates the grocery and meal planning concerns, and naturally resolves both bugs.
+
+## Design Decisions
+
+### 1. Bottom Tab Bar — 5 tabs becomes 6
+
+```
+Plan | Meals | Deals | Cart | Shop | Cook
+ 📋    🍴      🏷️     🏪    🛍️    👨‍🍳
+```
+
+- New `Meals` tab positioned second (after Plan), matching the weekly flow order
+- Icon: `UtensilsCrossed` from Lucide
+- Label: "Meals"
+- `SCREEN_TO_TAB` mapping updated: `chatbot` and `meal-creator` map to `meals`
+- Tab `min-w` drops from 60px to ~55px — fits comfortably on 375px+ screens
+
+### 2. Plan Screen — Simplified
+
+Plan.js renders only GroceryChecklist. No tabs, no sub-navigation.
+
+- Remove the Grocery List / Meals tab bar entirely
+- Remove mealMode state and sub-tab rendering
+- More vertical space for the grocery item list
+
+### 3. New Meals Screen — Segmented Control
+
+New `Meals.js` component with:
+
+- **Segmented control** at top for AI Meal Planner / Create Recipe
+  - Background: `bg-surface-alt` rounded pill container
+  - Active indicator: `bg-primary` sliding pill with Framer Motion `layoutId`
+  - Text: DM Sans, active = white/bold, inactive = muted
+  - Compact height (~36px)
+- Renders ChatBot (planner mode) or MealCreator (creator mode) below
+- Full-height layout (added to `FULL_HEIGHT_SCREENS`)
+- State persisted to localStorage as `mealsTabState`
+
+### 4. Bug #6 Fix — Automatic
+
+The meal agent sub-tabs no longer exist on the Plan screen. No code change needed beyond the restructuring.
+
+### 5. Bug #5 Fix — Remove Nested Scroll
+
+**Root cause:** GroceryChecklist's grouped items container has `max-h-[60vh] overflow-y-auto`, creating a nested scroll trap on mobile. Touch events inside the inner container don't propagate to the outer page scroll.
+
+**Fix:** Remove `max-h-[60vh] overflow-y-auto` from the grouped items container. Let items take their natural height and scroll with the single page-level scroll context in AppShell.
+
+Filter controls (Item Type, Data Source, Group by) scroll with the page — they are "set and forget" controls, not frequently toggled while browsing items. Sticky filters can be added later if needed.
+
+## Component Architecture Changes
+
+| File | Change |
+|------|--------|
+| `Meals.js` (new) | Segmented control + ChatBot/MealCreator. Manages mealMode state. |
+| `Plan.js` | Remove tab logic. Render GroceryChecklist directly. |
+| `BottomTabBar.js` | Add Meals tab (UtensilsCrossed, position 2). Update SCREEN_TO_TAB. |
+| `App.js` | Add `meals` routing case. Pass props to Meals. Add to FULL_HEIGHT_SCREENS. |
+| `Sidebar.js` | Add Meals nav item for desktop. |
+| `GroceryChecklist.js` | Remove `max-h-[60vh] overflow-y-auto` from grouped items container. |
+
+### Data Flow for Meals.js
+
+Props from App.js:
+- `selectedMeals`, `setSelectedMeals`, `refreshMeals`
+- `onNavigate`, `groceryListData`
+- `onUnsavedChanges`
+
+Internal state:
+- `mealMode` — "planner" or "creator", persisted to localStorage
+
+### Props Removed from Plan.js
+
+The following props are no longer needed by Plan (only by Meals):
+- `selectedMeals`, `setSelectedMeals`, `refreshMeals`
+
+Plan.js retains:
+- `onNavigate`, `onUnsavedChanges`, `onStartShopping`
+- `groceryListData`, `setGroceryListData`, `debugMode`

--- a/docs/plans/2026-03-23-nav-restructure-bugfix-plan.md
+++ b/docs/plans/2026-03-23-nav-restructure-bugfix-plan.md
@@ -1,0 +1,513 @@
+# Navigation Restructuring & Bug Fixes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Promote Meals to its own bottom bar tab, simplify Plan to just the grocery list, and fix the mobile scroll bug in GroceryChecklist.
+
+**Architecture:** Extract meal planning UI from Plan.js into a new Meals.js with a segmented control. Plan.js becomes a thin wrapper around GroceryChecklist. BottomTabBar grows from 5 to 6 tabs. GroceryChecklist's nested scroll container is removed.
+
+**Tech Stack:** React, Tailwind CSS, Framer Motion, Lucide icons, localStorage
+
+**Design doc:** `docs/plans/2026-03-23-nav-restructure-bugfix-design.md`
+
+---
+
+### Task 1: Fix Bug #5 — Remove nested scroll in GroceryChecklist
+
+**Files:**
+- Modify: `src/components/GroceryChecklist.js:1412`
+
+**Step 1: Fix the nested scroll**
+
+On line 1412, change:
+```jsx
+<div className="max-h-[60vh] overflow-y-auto overscroll-contain border border-default rounded-xl bg-surface">
+```
+to:
+```jsx
+<div className="border border-default rounded-xl bg-surface">
+```
+
+This removes the inner scroll container that traps touch events on mobile. Items now take their natural height and scroll with the page.
+
+**Step 2: Verify on mobile**
+
+Open the app on mobile (or responsive mode). Navigate to Plan > Grocery List. Touch inside the item list area and scroll. Confirm the page scrolls normally.
+
+**Step 3: Commit**
+
+```bash
+git add src/components/GroceryChecklist.js
+git commit -m "fix: remove nested scroll trap in grocery item list (Bug #5)"
+```
+
+---
+
+### Task 2: Create Meals.js — New component with segmented control
+
+**Files:**
+- Create: `src/components/Meals.js`
+
+**Step 1: Create the Meals component**
+
+```jsx
+import React, { useState, useCallback, useEffect } from 'react';
+import { MessageSquare, UtensilsCrossed } from 'lucide-react';
+import { motion } from 'framer-motion';
+import ChatBot from './ChatBot';
+import MealCreator from './MealCreator';
+
+/**
+ * Meals screen — segmented control switching between:
+ *   1. AI Meal Planner (ChatBot)
+ *   2. Create Recipe (MealCreator)
+ */
+
+const MEAL_MODES = [
+  { id: 'planner', label: 'AI Planner', icon: MessageSquare },
+  { id: 'creator', label: 'Create Recipe', icon: UtensilsCrossed },
+];
+
+const Meals = ({
+  onNavigate,
+  onUnsavedChanges,
+  selectedMeals,
+  setSelectedMeals,
+  refreshMeals,
+  groceryListData,
+  setGroceryListData,
+  debugMode,
+}) => {
+  const [mealMode, setMealMode] = useState(() => {
+    try {
+      return localStorage.getItem('mealsTabState') || 'planner';
+    } catch { return 'planner'; }
+  });
+
+  useEffect(() => {
+    try { localStorage.setItem('mealsTabState', mealMode); }
+    catch { /* ignore */ }
+  }, [mealMode]);
+
+  // Internal navigation: switch sub-mode instead of leaving screen
+  const handleMealNavigate = useCallback((screen) => {
+    if (screen === 'chatbot') {
+      setMealMode('planner');
+    } else if (screen === 'meal-creator') {
+      setMealMode('creator');
+    } else {
+      onNavigate(screen);
+    }
+  }, [onNavigate]);
+
+  return (
+    <div className="flex flex-col min-h-0 h-full">
+      {/* Segmented control */}
+      <div className="sticky top-12 lg:top-0 z-20 bg-surface/95 backdrop-blur-md border-b border-default px-4 py-3">
+        <div className="max-w-6xl mx-auto flex justify-center">
+          <div className="inline-flex bg-background rounded-full p-1 gap-0.5">
+            {MEAL_MODES.map((mode) => {
+              const Icon = mode.icon;
+              const isActive = mealMode === mode.id;
+              return (
+                <button
+                  key={mode.id}
+                  onClick={() => setMealMode(mode.id)}
+                  className={`relative flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-medium transition-colors duration-200 z-10 ${
+                    isActive ? 'text-white' : 'text-muted hover:text-body'
+                  }`}
+                >
+                  {isActive && (
+                    <motion.div
+                      layoutId="meals-segment"
+                      className="absolute inset-0 bg-primary rounded-full"
+                      transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                    />
+                  )}
+                  <span className="relative flex items-center gap-1.5">
+                    <Icon size={14} />
+                    {mode.label}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {mealMode === 'planner' && (
+          <ChatBot
+            onBack={() => onNavigate('plan')}
+            onNavigate={handleMealNavigate}
+            selectedMeals={selectedMeals}
+            setSelectedMeals={setSelectedMeals}
+            refreshMeals={refreshMeals}
+            groceryListData={groceryListData}
+            setGroceryListData={setGroceryListData}
+            debugMode={debugMode}
+          />
+        )}
+
+        {mealMode === 'creator' && (
+          <MealCreator
+            onBack={() => setMealMode('planner')}
+            onNavigate={handleMealNavigate}
+            selectedMeals={selectedMeals}
+            setSelectedMeals={setSelectedMeals}
+            refreshMeals={refreshMeals}
+            debugMode={debugMode}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Meals;
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/components/Meals.js
+git commit -m "feat: add Meals screen with segmented control"
+```
+
+---
+
+### Task 3: Simplify Plan.js — Remove tab system
+
+**Files:**
+- Modify: `src/components/Plan.js`
+
+**Step 1: Rewrite Plan.js**
+
+Replace entire file contents:
+
+```jsx
+import React from 'react';
+import GroceryChecklist from './GroceryChecklist';
+
+/**
+ * Plan screen — renders the weekly grocery checklist.
+ * Meal planning has been moved to the separate Meals screen.
+ */
+const Plan = ({
+  onNavigate,
+  onUnsavedChanges,
+  onStartShopping,
+  groceryListData,
+  setGroceryListData,
+  debugMode,
+}) => {
+  return (
+    <GroceryChecklist
+      onNavigate={onNavigate}
+      onUnsavedChanges={onUnsavedChanges}
+      onStartShopping={onStartShopping}
+      debugMode={debugMode}
+    />
+  );
+};
+
+export default Plan;
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/components/Plan.js
+git commit -m "refactor: simplify Plan to render only GroceryChecklist"
+```
+
+---
+
+### Task 4: Update BottomTabBar.js — Add Meals tab
+
+**Files:**
+- Modify: `src/components/BottomTabBar.js`
+
+**Step 1: Add UtensilsCrossed import**
+
+Line 2, change:
+```jsx
+import { ClipboardList, Tag, Store, ShoppingBag, ChefHat } from "lucide-react";
+```
+to:
+```jsx
+import { ClipboardList, UtensilsCrossed, Tag, Store, ShoppingBag, ChefHat } from "lucide-react";
+```
+
+**Step 2: Add Meals tab to TABS array**
+
+Lines 13-19, change:
+```jsx
+const TABS = [
+  { id: "plan", label: "Plan", icon: ClipboardList },
+  { id: "deals", label: "Deals", icon: Tag },
+  { id: "cart", label: "Cart", icon: Store },
+  { id: "shop", label: "Shop", icon: ShoppingBag },
+  { id: "cook", label: "Cook", icon: ChefHat },
+];
+```
+to:
+```jsx
+const TABS = [
+  { id: "plan", label: "Plan", icon: ClipboardList },
+  { id: "meals", label: "Meals", icon: UtensilsCrossed },
+  { id: "deals", label: "Deals", icon: Tag },
+  { id: "cart", label: "Cart", icon: Store },
+  { id: "shop", label: "Shop", icon: ShoppingBag },
+  { id: "cook", label: "Cook", icon: ChefHat },
+];
+```
+
+**Step 3: Update SCREEN_TO_TAB mappings**
+
+Lines 22-39, change `chatbot` and `meal-creator` to map to `"meals"` instead of `"plan"`. Add `meals: "meals"`:
+
+```jsx
+const SCREEN_TO_TAB = {
+  // New IDs
+  plan: "plan",
+  meals: "meals",
+  deals: "deals",
+  cart: "cart",
+  shop: "shop",
+  cook: "cook",
+  // Legacy IDs (still routable during transition)
+  grocery: "plan",
+  chatbot: "meals",
+  "meal-creator": "meals",
+  "recipe-ingredients": "meals",
+  "smart-deals": "deals",
+  coupons: "deals",
+  "heb-cart": "cart",
+  "in-store": "shop",
+  "recipe-instructions": "cook",
+};
+```
+
+**Step 4: Reduce tab min-width for 6 tabs**
+
+Line 59, change:
+```jsx
+className={`flex flex-col items-center gap-1 px-3 py-1.5 rounded-xl min-w-[60px] min-h-[44px] transition-all duration-200 relative ${
+```
+to:
+```jsx
+className={`flex flex-col items-center gap-1 px-2 py-1.5 rounded-xl min-w-[52px] min-h-[44px] transition-all duration-200 relative ${
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/components/BottomTabBar.js
+git commit -m "feat: add Meals tab to bottom navigation bar"
+```
+
+---
+
+### Task 5: Update App.js — Wire up Meals routing
+
+**Files:**
+- Modify: `src/components/App.js`
+
+**Step 1: Add Meals import**
+
+After line 19 (`import Plan from "./Plan";`), add:
+```jsx
+import Meals from "./Meals";
+```
+
+**Step 2: Add UtensilsCrossed import**
+
+Line 2, add `UtensilsCrossed` to the lucide import:
+```jsx
+import { ClipboardList, UtensilsCrossed, Tag, Store, ShoppingBag, ChefHat } from "lucide-react";
+```
+
+**Step 3: Add "meals" to FULL_HEIGHT_SCREENS**
+
+Line 25, change:
+```jsx
+const FULL_HEIGHT_SCREENS = new Set(["plan", "chatbot", "meal-creator"]);
+```
+to:
+```jsx
+const FULL_HEIGHT_SCREENS = new Set(["plan", "meals", "chatbot", "meal-creator"]);
+```
+
+**Step 4: Add "meals" to VALID_SCREENS**
+
+Line 30, change:
+```jsx
+  "home", "plan", "deals", "cart", "shop", "cook",
+```
+to:
+```jsx
+  "home", "plan", "meals", "deals", "cart", "shop", "cook",
+```
+
+**Step 5: Add Meals to navigation array**
+
+Lines 52-57, change:
+```jsx
+const navigation = [
+  { id: "plan", name: "Plan Meals & List", icon: ClipboardList },
+  { id: "deals", name: "Deals & Coupons", icon: Tag },
+  { id: "cart", name: "HEB Cart Builder", icon: Store },
+  { id: "shop", name: "Shop In-Store", icon: ShoppingBag },
+  { id: "cook", name: "Cook Recipes", icon: ChefHat },
+];
+```
+to:
+```jsx
+const navigation = [
+  { id: "plan", name: "Grocery List", icon: ClipboardList },
+  { id: "meals", name: "Meal Planning", icon: UtensilsCrossed },
+  { id: "deals", name: "Deals & Coupons", icon: Tag },
+  { id: "cart", name: "HEB Cart Builder", icon: Store },
+  { id: "shop", name: "Shop In-Store", icon: ShoppingBag },
+  { id: "cook", name: "Cook Recipes", icon: ChefHat },
+];
+```
+
+Note: "Plan Meals & List" renamed to "Grocery List" since meals moved out.
+
+**Step 6: Simplify Plan case — remove meal props**
+
+Lines 207-220, change:
+```jsx
+      case "plan":
+        return (
+          <Plan
+            onNavigate={navigateToScreen}
+            onUnsavedChanges={setHasUnsavedChanges}
+            onStartShopping={handleStartShopping}
+            selectedMeals={selectedMeals}
+            setSelectedMeals={setSelectedMeals}
+            refreshMeals={refreshMeals}
+            groceryListData={groceryListData}
+            setGroceryListData={setGroceryListData}
+            debugMode={debugMode}
+          />
+        );
+```
+to:
+```jsx
+      case "plan":
+        return (
+          <Plan
+            onNavigate={navigateToScreen}
+            onUnsavedChanges={setHasUnsavedChanges}
+            onStartShopping={handleStartShopping}
+            groceryListData={groceryListData}
+            setGroceryListData={setGroceryListData}
+            debugMode={debugMode}
+          />
+        );
+```
+
+**Step 7: Add Meals case**
+
+After the Plan case (after line ~220), add:
+```jsx
+      // --- Meals tab (AI Meal Planner + Create Recipe) ---
+      case "meals":
+        return (
+          <Meals
+            onNavigate={navigateToScreen}
+            onUnsavedChanges={setHasUnsavedChanges}
+            selectedMeals={selectedMeals}
+            setSelectedMeals={setSelectedMeals}
+            refreshMeals={refreshMeals}
+            groceryListData={groceryListData}
+            setGroceryListData={setGroceryListData}
+            debugMode={debugMode}
+          />
+        );
+```
+
+**Step 8: Update legacy chatbot/meal-creator onBack targets**
+
+Lines 223-245, update the `onBack` props to navigate to `"meals"` instead of `"plan"`:
+
+ChatBot case (~line 226):
+```jsx
+            onBack={() => navigateToScreen("meals")}
+```
+
+MealCreator case (~line 239):
+```jsx
+            onBack={() => navigateToScreen("meals")}
+```
+
+**Step 9: Commit**
+
+```bash
+git add src/components/App.js
+git commit -m "feat: wire up Meals screen routing in App"
+```
+
+---
+
+### Task 6: Update Sidebar.js — Fix legacy mappings
+
+**Files:**
+- Modify: `src/components/Sidebar.js`
+
+**Step 1: Update LEGACY_TO_NEW mappings**
+
+Lines 17-27, change `chatbot` and `meal-creator` to map to `"meals"`:
+```jsx
+  const LEGACY_TO_NEW = {
+    grocery: "plan",
+    chatbot: "meals",
+    "meal-creator": "meals",
+    "recipe-ingredients": "meals",
+    "smart-deals": "deals",
+    coupons: "deals",
+    "heb-cart": "cart",
+    "in-store": "shop",
+    "recipe-instructions": "cook",
+  };
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/components/Sidebar.js
+git commit -m "refactor: update sidebar legacy mappings for meals tab"
+```
+
+---
+
+### Task 7: Smoke test the full flow
+
+**Step 1: Start the dev server**
+
+```bash
+npm start
+```
+
+**Step 2: Verify on mobile viewport**
+
+- Bottom bar shows 6 tabs: Plan, Meals, Deals, Cart, Shop, Cook
+- Plan tab shows only the grocery checklist (no Grocery List / Meals tabs)
+- Scrolling inside the grocery item list works normally on mobile
+- Meals tab shows segmented control with AI Planner / Create Recipe
+- Switching segments loads ChatBot or MealCreator
+- Segment state persists across tab switches (navigate away, come back)
+
+**Step 3: Verify on desktop viewport**
+
+- Sidebar shows "Grocery List" and "Meal Planning" as separate nav items
+- Both navigate correctly
+- No layout overlap or z-index issues
+
+**Step 4: Clean up old localStorage key**
+
+The old `planTabState` localStorage key stored `{ activeTab, mealMode }`. The new code uses `mealsTabState` (string). The old key is harmless (Plan.js no longer reads it) but can be cleaned up in a future pass.

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
-import { ClipboardList, Tag, Store, ShoppingBag, ChefHat } from "lucide-react";
+import { ClipboardList, UtensilsCrossed, Tag, Store, ShoppingBag, ChefHat } from "lucide-react";
 import { Toaster } from "react-hot-toast";
 import { motion, AnimatePresence } from "framer-motion";
 import { getWeekDates } from "../utils/weekDates";
@@ -17,16 +17,17 @@ import Coupons from "./Coupons";
 import HebCart from "./HebCart";
 import Deals from "./Deals";
 import Plan from "./Plan";
+import Meals from "./Meals";
 import FeedbackFAB from "./FeedbackFAB";
 
 // Screens that need fixed-height layout (flex column with internal scroll)
 // — chat interfaces pin input at bottom, so they need a defined container height
-const FULL_HEIGHT_SCREENS = new Set(["plan", "chatbot", "meal-creator"]);
+const FULL_HEIGHT_SCREENS = new Set(["plan", "meals", "chatbot", "meal-creator"]);
 
 // New primary screen IDs + legacy IDs still routable during transition
 const VALID_SCREENS = [
   // New flow screens
-  "home", "plan", "deals", "cart", "shop", "cook",
+  "home", "plan", "meals", "deals", "cart", "shop", "cook",
   // Legacy IDs — still routable for internal navigation during phased migration
   "grocery", "chatbot", "meal-creator", "recipe-ingredients", "recipe-instructions",
   "in-store", "coupons", "heb-cart", "smart-deals",
@@ -49,7 +50,8 @@ const isDebugMode = () => {
 
 // Navigation list for the desktop sidebar (new flow)
 const navigation = [
-  { id: "plan", name: "Plan Meals & List", icon: ClipboardList },
+  { id: "plan", name: "Grocery List", icon: ClipboardList },
+  { id: "meals", name: "Meal Planning", icon: UtensilsCrossed },
   { id: "deals", name: "Deals & Coupons", icon: Tag },
   { id: "cart", name: "HEB Cart Builder", icon: Store },
   { id: "shop", name: "Shop In-Store", icon: ShoppingBag },
@@ -190,13 +192,22 @@ const App = () => {
           />
         );
 
-      // --- Plan tab (unified Meals + Grocery List) ---
+      // --- Plan tab (Grocery List) ---
       case "plan":
         return (
           <Plan
             onNavigate={navigateToScreen}
             onUnsavedChanges={setHasUnsavedChanges}
             onStartShopping={handleStartShopping}
+            debugMode={debugMode}
+          />
+        );
+
+      // --- Meals tab (AI Meal Planner + Create Recipe) ---
+      case "meals":
+        return (
+          <Meals
+            onNavigate={navigateToScreen}
             selectedMeals={selectedMeals}
             setSelectedMeals={setSelectedMeals}
             refreshMeals={refreshMeals}
@@ -210,7 +221,7 @@ const App = () => {
       case "chatbot":
         return (
           <ChatBot
-            onBack={() => navigateToScreen("plan")}
+            onBack={() => navigateToScreen("meals")}
             onNavigate={navigateToScreen}
             selectedMeals={selectedMeals}
             setSelectedMeals={setSelectedMeals}
@@ -223,7 +234,7 @@ const App = () => {
       case "meal-creator":
         return (
           <MealCreator
-            onBack={() => navigateToScreen("plan")}
+            onBack={() => navigateToScreen("meals")}
             onNavigate={navigateToScreen}
             selectedMeals={selectedMeals}
             setSelectedMeals={setSelectedMeals}

--- a/src/components/BottomTabBar.js
+++ b/src/components/BottomTabBar.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { ClipboardList, Tag, Store, ShoppingBag, ChefHat } from "lucide-react";
+import { ClipboardList, UtensilsCrossed, Tag, Store, ShoppingBag, ChefHat } from "lucide-react";
 import { motion } from "framer-motion";
 
 /**
@@ -12,6 +12,7 @@ import { motion } from "framer-motion";
 
 const TABS = [
   { id: "plan", label: "Plan", icon: ClipboardList },
+  { id: "meals", label: "Meals", icon: UtensilsCrossed },
   { id: "deals", label: "Deals", icon: Tag },
   { id: "cart", label: "Cart", icon: Store },
   { id: "shop", label: "Shop", icon: ShoppingBag },
@@ -22,15 +23,16 @@ const TABS = [
 const SCREEN_TO_TAB = {
   // New IDs
   plan: "plan",
+  meals: "meals",
   deals: "deals",
   cart: "cart",
   shop: "shop",
   cook: "cook",
   // Legacy IDs (still routable during transition)
   grocery: "plan",
-  chatbot: "plan",
-  "meal-creator": "plan",
-  "recipe-ingredients": "plan",
+  chatbot: "meals",
+  "meal-creator": "meals",
+  "recipe-ingredients": "meals",
   "smart-deals": "deals",
   coupons: "deals",
   "heb-cart": "cart",
@@ -56,7 +58,7 @@ const BottomTabBar = ({ currentScreen, onNavigate }) => {
               <button
                 key={tab.id}
                 onClick={() => onNavigate(tab.id)}
-                className={`flex flex-col items-center gap-1 px-3 py-1.5 rounded-xl min-w-[60px] min-h-[44px] transition-all duration-200 relative ${
+                className={`flex flex-col items-center gap-1 px-2 py-1.5 rounded-xl min-w-[52px] min-h-[44px] transition-all duration-200 relative ${
                   isActive
                     ? "text-primary"
                     : "text-muted hover:text-body"

--- a/src/components/BottomTabBar.js
+++ b/src/components/BottomTabBar.js
@@ -3,9 +3,9 @@ import { ClipboardList, UtensilsCrossed, Tag, Store, ShoppingBag, ChefHat } from
 import { motion } from "framer-motion";
 
 /**
- * Mobile bottom tab bar — 5 flat tabs for the weekly flow.
+ * Mobile bottom tab bar — 6 tabs for the weekly flow.
  *
- * Tabs: Plan | Deals | Cart | Shop | Cook
+ * Tabs: Plan | Meals | Deals | Cart | Shop | Cook
  *
  * Home is accessed via the header logo, not a tab.
  */

--- a/src/components/GroceryChecklist.js
+++ b/src/components/GroceryChecklist.js
@@ -1409,7 +1409,7 @@ const GroceryChecklist = ({ onNavigate, onUnsavedChanges, onStartShopping, debug
             </div>
           </div>
 
-          <div className="max-h-[60vh] overflow-y-auto overscroll-contain border border-default rounded-xl bg-surface">
+          <div className="border border-default rounded-xl bg-surface">
             <div className="space-y-1 p-2">
               {currentGroupItems.map((item) => (
                 <GroceryItem

--- a/src/components/Meals.js
+++ b/src/components/Meals.js
@@ -1,0 +1,115 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { MessageSquare, UtensilsCrossed } from 'lucide-react';
+import { motion } from 'framer-motion';
+import ChatBot from './ChatBot';
+import MealCreator from './MealCreator';
+
+/**
+ * Meals screen — segmented control switching between:
+ *   1. AI Meal Planner (ChatBot)
+ *   2. Create Recipe (MealCreator)
+ */
+
+const MEAL_MODES = [
+  { id: 'planner', label: 'AI Planner', icon: MessageSquare },
+  { id: 'creator', label: 'Create Recipe', icon: UtensilsCrossed },
+];
+
+const Meals = ({
+  onNavigate,
+  onUnsavedChanges,
+  selectedMeals,
+  setSelectedMeals,
+  refreshMeals,
+  groceryListData,
+  setGroceryListData,
+  debugMode,
+}) => {
+  const [mealMode, setMealMode] = useState(() => {
+    try {
+      return localStorage.getItem('mealsTabState') || 'planner';
+    } catch { return 'planner'; }
+  });
+
+  useEffect(() => {
+    try { localStorage.setItem('mealsTabState', mealMode); }
+    catch { /* ignore */ }
+  }, [mealMode]);
+
+  // Internal navigation: switch sub-mode instead of leaving screen
+  const handleMealNavigate = useCallback((screen) => {
+    if (screen === 'chatbot') {
+      setMealMode('planner');
+    } else if (screen === 'meal-creator') {
+      setMealMode('creator');
+    } else {
+      onNavigate(screen);
+    }
+  }, [onNavigate]);
+
+  return (
+    <div className="flex flex-col min-h-0 h-full">
+      {/* Segmented control */}
+      <div className="sticky top-12 lg:top-0 z-20 bg-surface/95 backdrop-blur-md border-b border-default px-4 py-3">
+        <div className="max-w-6xl mx-auto flex justify-center">
+          <div className="inline-flex bg-background rounded-full p-1 gap-0.5">
+            {MEAL_MODES.map((mode) => {
+              const Icon = mode.icon;
+              const isActive = mealMode === mode.id;
+              return (
+                <button
+                  key={mode.id}
+                  onClick={() => setMealMode(mode.id)}
+                  className={`relative flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-medium transition-colors duration-200 z-10 ${
+                    isActive ? 'text-white' : 'text-muted hover:text-body'
+                  }`}
+                >
+                  {isActive && (
+                    <motion.div
+                      layoutId="meals-segment"
+                      className="absolute inset-0 bg-primary rounded-full"
+                      transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                    />
+                  )}
+                  <span className="relative flex items-center gap-1.5">
+                    <Icon size={14} />
+                    {mode.label}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {mealMode === 'planner' && (
+          <ChatBot
+            onBack={() => onNavigate('plan')}
+            onNavigate={handleMealNavigate}
+            selectedMeals={selectedMeals}
+            setSelectedMeals={setSelectedMeals}
+            refreshMeals={refreshMeals}
+            groceryListData={groceryListData}
+            setGroceryListData={setGroceryListData}
+            debugMode={debugMode}
+          />
+        )}
+
+        {mealMode === 'creator' && (
+          <MealCreator
+            onBack={() => setMealMode('planner')}
+            onNavigate={handleMealNavigate}
+            selectedMeals={selectedMeals}
+            setSelectedMeals={setSelectedMeals}
+            refreshMeals={refreshMeals}
+            debugMode={debugMode}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Meals;

--- a/src/components/Meals.js
+++ b/src/components/Meals.js
@@ -17,7 +17,6 @@ const MEAL_MODES = [
 
 const Meals = ({
   onNavigate,
-  onUnsavedChanges,
   selectedMeals,
   setSelectedMeals,
   refreshMeals,

--- a/src/components/Plan.js
+++ b/src/components/Plan.js
@@ -1,157 +1,25 @@
-import React, { useState, useCallback, useEffect } from 'react';
-import { ClipboardList, MessageSquare, UtensilsCrossed } from 'lucide-react';
-import ChatBot from './ChatBot';
-import MealCreator from './MealCreator';
+import React from 'react';
 import GroceryChecklist from './GroceryChecklist';
 
 /**
- * Plan screen — unified container with two primary tabs:
- *   1. Meals — AI meal planning (ChatBot + MealCreator sub-modes)
- *   2. Grocery List — weekly checklist with one-off quick-add
- *
- * The Meals tab has sub-modes: "planner" (ChatBot) and "creator" (MealCreator).
+ * Plan screen — renders the weekly grocery checklist.
+ * Meal planning has been moved to the separate Meals screen.
  */
-
-const PLAN_TABS = [
-  { id: 'list', label: 'Grocery List', icon: ClipboardList },
-  { id: 'meals', label: 'Meals', icon: UtensilsCrossed },
-];
-
-const MEAL_MODES = [
-  { id: 'planner', label: 'AI Meal Planner', icon: MessageSquare },
-  { id: 'creator', label: 'Create Recipe', icon: UtensilsCrossed },
-];
-
 const Plan = ({
   onNavigate,
   onUnsavedChanges,
   onStartShopping,
-  selectedMeals,
-  setSelectedMeals,
-  refreshMeals,
   groceryListData,
   setGroceryListData,
   debugMode,
 }) => {
-  const [activeTab, setActiveTab] = useState(() => {
-    try {
-      const saved = localStorage.getItem('planTabState');
-      return saved ? JSON.parse(saved).activeTab || 'list' : 'list';
-    } catch { return 'list'; }
-  });
-  const [mealMode, setMealMode] = useState(() => {
-    try {
-      const saved = localStorage.getItem('planTabState');
-      return saved ? JSON.parse(saved).mealMode || 'planner' : 'planner';
-    } catch { return 'planner'; }
-  });
-
-  // Persist active tab + meal sub-mode to localStorage
-  useEffect(() => {
-    try {
-      localStorage.setItem('planTabState', JSON.stringify({ activeTab, mealMode }));
-    } catch { /* ignore */ }
-  }, [activeTab, mealMode]);
-
-  // When ChatBot navigates to MealCreator (or vice versa), switch sub-mode instead
-  const handleMealNavigate = useCallback((screen) => {
-    if (screen === 'chatbot') {
-      setMealMode('planner');
-    } else if (screen === 'meal-creator') {
-      setMealMode('creator');
-    } else {
-      // Pass through to parent for other screens (recipe-ingredients, etc.)
-      onNavigate(screen);
-    }
-  }, [onNavigate]);
-
   return (
-    <div className="flex flex-col min-h-0 h-full">
-      {/* Tab bar */}
-      <div className="sticky top-12 lg:top-0 z-20 bg-surface/95 backdrop-blur-md border-b border-default px-4 pt-2">
-        <div className="max-w-6xl mx-auto flex gap-1">
-          {PLAN_TABS.map((tab) => {
-            const Icon = tab.icon;
-            const isActive = activeTab === tab.id;
-            return (
-              <button
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium border-b-2 transition-all ${
-                  isActive
-                    ? 'border-primary text-primary'
-                    : 'border-transparent text-muted hover:text-body hover:border-default'
-                }`}
-              >
-                <Icon size={16} />
-                {tab.label}
-              </button>
-            );
-          })}
-        </div>
-
-        {/* Meal sub-mode switcher (only when Meals tab is active) */}
-        {activeTab === 'meals' && (
-          <div className="max-w-6xl mx-auto flex gap-1 pb-2 pt-1">
-            {MEAL_MODES.map((mode) => {
-              const Icon = mode.icon;
-              const isActive = mealMode === mode.id;
-              return (
-                <button
-                  key={mode.id}
-                  onClick={() => setMealMode(mode.id)}
-                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
-                    isActive
-                      ? 'bg-primary text-white'
-                      : 'bg-background text-body hover:bg-default'
-                  }`}
-                >
-                  <Icon size={12} />
-                  {mode.label}
-                </button>
-              );
-            })}
-          </div>
-        )}
-      </div>
-
-      {/* Tab content — overflow-y-auto lets GroceryChecklist scroll;
-           ChatBot/MealCreator have their own internal overflow handling */}
-      <div className="flex-1 min-h-0 overflow-y-auto">
-        {activeTab === 'list' && (
-          <GroceryChecklist
-            onNavigate={onNavigate}
-            onUnsavedChanges={onUnsavedChanges}
-            onStartShopping={onStartShopping}
-            debugMode={debugMode}
-          />
-        )}
-
-        {activeTab === 'meals' && mealMode === 'planner' && (
-          <ChatBot
-            onBack={() => setActiveTab('list')}
-            onNavigate={handleMealNavigate}
-            selectedMeals={selectedMeals}
-            setSelectedMeals={setSelectedMeals}
-            refreshMeals={refreshMeals}
-            groceryListData={groceryListData}
-            setGroceryListData={setGroceryListData}
-            debugMode={debugMode}
-          />
-        )}
-
-        {activeTab === 'meals' && mealMode === 'creator' && (
-          <MealCreator
-            onBack={() => setMealMode('planner')}
-            onNavigate={handleMealNavigate}
-            selectedMeals={selectedMeals}
-            setSelectedMeals={setSelectedMeals}
-            refreshMeals={refreshMeals}
-            debugMode={debugMode}
-          />
-        )}
-      </div>
-    </div>
+    <GroceryChecklist
+      onNavigate={onNavigate}
+      onUnsavedChanges={onUnsavedChanges}
+      onStartShopping={onStartShopping}
+      debugMode={debugMode}
+    />
   );
 };
 

--- a/src/components/Plan.js
+++ b/src/components/Plan.js
@@ -9,8 +9,6 @@ const Plan = ({
   onNavigate,
   onUnsavedChanges,
   onStartShopping,
-  groceryListData,
-  setGroceryListData,
   debugMode,
 }) => {
   return (

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -16,9 +16,9 @@ const Sidebar = ({
   // Map legacy screen IDs to new parent IDs for active highlighting
   const LEGACY_TO_NEW = {
     grocery: "plan",
-    chatbot: "plan",
-    "meal-creator": "plan",
-    "recipe-ingredients": "plan",
+    chatbot: "meals",
+    "meal-creator": "meals",
+    "recipe-ingredients": "meals",
     "smart-deals": "deals",
     coupons: "deals",
     "heb-cart": "cart",


### PR DESCRIPTION
## Summary

- **Bug #5 fixed**: Removed nested `max-h-[60vh] overflow-y-auto` scroll trap in GroceryChecklist that prevented mobile users from scrolling inside the item list
- **Bug #6 fixed**: Eliminated meal agent menu overlapping the grocery header by separating Meals into its own screen
- **Idea #7 implemented**: Promoted Meals to its own bottom tab, reducing navigation from 3 levels to 2. Plan screen now shows only the grocery checklist. New Meals screen has a segmented control (AI Planner | Create Recipe) with Framer Motion animated pill indicator

## Files Changed

| File | Change |
|------|--------|
| `src/components/Meals.js` | **New** — Segmented control + ChatBot/MealCreator |
| `src/components/Plan.js` | Simplified from 158 lines to 27 (just GroceryChecklist) |
| `src/components/BottomTabBar.js` | 6 tabs (added Meals with UtensilsCrossed icon) |
| `src/components/App.js` | Meals routing, updated navigation array |
| `src/components/Sidebar.js` | Updated legacy screen mappings |
| `src/components/GroceryChecklist.js` | Removed nested scroll trap CSS |
| `docs/plans/2026-03-23-*` | Design doc and implementation plan |

## Test plan

- [ ] Mobile: Bottom bar shows 6 tabs (Plan, Meals, Deals, Cart, Shop, Cook)
- [ ] Mobile: Plan tab shows only grocery checklist, no tab bar at top
- [ ] Mobile: Scroll inside grocery item list works (touch anywhere in list)
- [ ] Mobile: No header overlap between meal menu and grocery filters
- [ ] Mobile: Meals tab shows segmented control (AI Planner / Create Recipe)
- [ ] Mobile: Switching segments loads correct chat interface
- [ ] Mobile: Segment state persists across tab switches (localStorage)
- [ ] Desktop: Sidebar shows Grocery List and Meal Planning as separate items
- [ ] Desktop: Both sidebar items navigate correctly
- [ ] No console errors on any screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)