### PR TITLE
fix: replace fixed-position tab bar with flex layout

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -134,7 +134,7 @@ const App = () => {
     }
     setCurrentScreen(target);
     window.history.pushState({ screen: target }, "", `#${target}`);
-    window.scrollTo(0, 0);
+    document.querySelector('main')?.scrollTo(0, 0);
   }, []);
 
   const handleStartShopping = useCallback((data) => {
@@ -156,7 +156,7 @@ const App = () => {
       } else {
         setCurrentScreen("home");
       }
-      window.scrollTo(0, 0);
+      document.querySelector('main')?.scrollTo(0, 0);
     };
 
     window.addEventListener("popstate", handlePopState);

--- a/src/components/AppShell.js
+++ b/src/components/AppShell.js
@@ -35,16 +35,16 @@ const AppShell = ({ currentScreen, onNavigate, navigation, children }) => {
         </header>
 
         {/* Page content */}
-        <main className="flex-1 min-h-0 overflow-auto pb-24 lg:pb-0">
+        <main className="flex-1 min-h-0 overflow-auto">
           {children}
         </main>
-      </div>
 
-      {/* Mobile bottom tab bar */}
-      <BottomTabBar
-        currentScreen={currentScreen}
-        onNavigate={onNavigate}
-      />
+        {/* Mobile bottom tab bar — flex child, not fixed, takes natural height */}
+        <BottomTabBar
+          currentScreen={currentScreen}
+          onNavigate={onNavigate}
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/BottomTabBar.js
+++ b/src/components/BottomTabBar.js
@@ -44,7 +44,7 @@ const BottomTabBar = ({ currentScreen, onNavigate }) => {
   const activeTabId = SCREEN_TO_TAB[currentScreen] || null;
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-40 lg:hidden">
+    <div className="shrink-0 lg:hidden">
       <div
         className="bg-surface border-t border-default"
         style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}

--- a/src/components/ChatBot.js
+++ b/src/components/ChatBot.js
@@ -699,7 +699,7 @@ const ChatBot = ({ onBack, onNavigate, selectedMeals: parentSelectedMeals, setSe
   // Removed getFallbackIngredients function since we're not using it anymore
 
   return (
-    <div className="h-full flex flex-col lg:flex-row lg:max-w-7xl lg:mx-auto lg:gap-6 lg:p-4 relative pb-16 lg:pb-0">
+    <div className="h-full flex flex-col lg:flex-row lg:max-w-7xl lg:mx-auto lg:gap-6 lg:p-4 relative">
       {/* Loading Overlay */}
       {isGeneratingGroceryList && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
@@ -904,7 +904,7 @@ const ChatBot = ({ onBack, onNavigate, selectedMeals: parentSelectedMeals, setSe
         </div>
 
         {/* Input Area */}
-        <div className="p-4 lg:p-6 bg-surface border-t border-default">
+        <div className="p-4 pb-6 lg:p-6 bg-surface border-t border-default">
           <div className="flex gap-3">
             <div className="flex-1 relative">
               <textarea

--- a/src/components/FeedbackFAB.js
+++ b/src/components/FeedbackFAB.js
@@ -144,7 +144,8 @@ const FeedbackFAB = ({ currentScreen }) => {
           whileHover={{ scale: 1.1 }}
           whileTap={{ scale: 0.9 }}
           onClick={handleOpen}
-          className="fixed bottom-24 right-4 lg:bottom-8 lg:right-8 z-50 w-14 h-14 rounded-full bg-primary text-white shadow-warm-lg flex items-center justify-center hover:bg-primary-hover transition-colors duration-200"
+          className="fixed right-4 lg:right-8 z-50 w-14 h-14 rounded-full bg-primary text-white shadow-warm-lg flex items-center justify-center hover:bg-primary-hover transition-colors duration-200"
+          style={{ bottom: ['meals', 'chatbot', 'meal-creator'].includes(currentScreen) ? 'calc(var(--tab-bar-height) + 7rem)' : 'calc(var(--tab-bar-height) + 1rem)' }}
           aria-label="Send feedback"
         >
           <MessageSquarePlus size={24} />

--- a/src/components/GroceryChecklist.js
+++ b/src/components/GroceryChecklist.js
@@ -623,7 +623,7 @@ const GroceryChecklist = ({ onNavigate, onUnsavedChanges, onStartShopping, debug
 
   if (isLoading) {
     return (
-      <div className="max-w-4xl mx-auto p-6 pb-24 lg:pb-6 bg-surface rounded-2xl shadow-warm border border-default transition-colors duration-200">
+      <div className="max-w-4xl mx-auto p-6 bg-surface rounded-2xl shadow-warm border border-default transition-colors duration-200">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto"></div>
           <p className="mt-4 text-body">
@@ -640,7 +640,7 @@ const GroceryChecklist = ({ onNavigate, onUnsavedChanges, onStartShopping, debug
   if (showFinalList) {
     const finalList = getFinalGroceryList();
     return (
-      <div className="max-w-4xl mx-auto p-6 pb-24 lg:pb-6 bg-surface rounded-2xl shadow-warm border border-default transition-colors duration-200">
+      <div className="max-w-4xl mx-auto p-6 bg-surface rounded-2xl shadow-warm border border-default transition-colors duration-200">
         <div className="flex items-center gap-3 mb-6">
           <ShoppingCart className="text-primary" size={28} />
           <h1 className="text-2xl font-bold text-heading font-display">
@@ -915,7 +915,7 @@ const GroceryChecklist = ({ onNavigate, onUnsavedChanges, onStartShopping, debug
   const currentGroupItems = getItemsByGroup(activeTab);
 
   return (
-    <div className="max-w-4xl mx-auto pb-24 lg:pb-0">
+    <div className="max-w-4xl mx-auto">
       {/* Add Item Side Panel */}
       {showAddPanel && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-end z-50">

--- a/src/components/MealCreator.js
+++ b/src/components/MealCreator.js
@@ -576,7 +576,7 @@ const MealCreator = ({ onBack, onNavigate, selectedMeals, setSelectedMeals, refr
   };
 
   return (
-    <div className="h-full flex flex-col lg:max-w-5xl lg:mx-auto lg:p-4 pb-16 lg:pb-0">
+    <div className="h-full flex flex-col lg:max-w-5xl lg:mx-auto lg:p-4">
       {/* Building Overlay */}
       {isBuilding && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
@@ -953,7 +953,7 @@ const MealCreator = ({ onBack, onNavigate, selectedMeals, setSelectedMeals, refr
 
         {/* Input Area (Phase 1 only) */}
         {phase === 1 && (
-          <div className="p-4 lg:p-6 bg-surface border-t border-default">
+          <div className="p-4 pb-6 lg:p-6 bg-surface border-t border-default">
             <div className="flex gap-3">
               <div className="flex-1 relative">
                 <textarea

--- a/src/components/RecipeInstructions.js
+++ b/src/components/RecipeInstructions.js
@@ -1373,7 +1373,7 @@ const RecipeInstructions = ({ onNavigate, recipeId, selectedMeals = [], debugMod
 
       {/* Floating Timer Pill (Feature 6) */}
       {(timerRunning || timerSeconds > 0) && (
-        <div className={`fixed bottom-[max(1rem,env(safe-area-inset-bottom))] left-1/2 -translate-x-1/2 z-30 flex items-center gap-3
+        <div style={{ bottom: 'calc(var(--tab-bar-height) + 0.5rem)' }} className={`fixed left-1/2 -translate-x-1/2 z-50 flex items-center gap-3
           px-4 py-3 rounded-full shadow-warm-lg ${
           kitchenMode ? 'bg-gray-800 border border-amber-500/50' : 'bg-surface border border-accent'
         }`}>

--- a/src/index.css
+++ b/src/index.css
@@ -77,6 +77,18 @@
     --color-sidebar-border: #3A3D44;
   }
 
+  /* Tab bar height — used ONLY by fixed-position floating elements (FAB, timer pill).
+     Screen content does NOT need this; the flex layout handles clearance automatically. */
+  :root {
+    --tab-bar-height: calc(3.75rem + max(0.5rem, env(safe-area-inset-bottom)));
+  }
+
+  @media (min-width: 1024px) {
+    :root {
+      --tab-bar-height: 0px;
+    }
+  }
+
   html {
     font-family: 'DM Sans', system-ui, sans-serif;
   }


### PR DESCRIPTION
## Summary
- **Root cause**: Bottom tab bar used `position: fixed`, requiring scattered `pb-*` padding hacks across 6+ components. Each screen handled it differently (or didn't), causing 5+ user bug reports of content hidden behind the tab bar.
- **Fix**: Replace fixed positioning with flex layout — tab bar is now a natural flex child in AppShell's column. `<main>` fills remaining space automatically. No padding compensation needed for any screen, current or future.
- **Bonus fixes**: FeedbackFAB repositioned higher on chat screens to avoid overlapping Send button, RecipeInstructions timer pill z-index fixed (was behind tab bar), scroll-to-top now targets correct scroll container.

## Test plan
- [x] All 18 tests pass (4 suites)
- [x] Verified Plan, Meals, Deals, Cart, Cook, Home screens on mobile (375px)
- [x] Verified desktop layout (1280px) — sidebar visible, no tab bar
- [x] Chat input visible and usable on Meals screen
- [x] FeedbackFAB doesn't overlap Send button on chat screens
- [x] Bottom content (Review Selection button, etc.) fully visible above tab bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)